### PR TITLE
LocalEnvironment, default build steps

### DIFF
--- a/LocalBuild.py
+++ b/LocalBuild.py
@@ -1,11 +1,24 @@
 
-import os
-import platform
+# BUILT IN MODULES
+# import os
+# import platform
 import sys
 
-sys.path.append("scripts")
+
+# PYTHON PROJECT MODULES
+sys.path.append("scripts")  # now we can import modules from <currentDirectory>/scripts
 import GlobalBuildRules
+
 
 class LocalBuild(GlobalBuildRules.GlobalBuild):
     def __init__(self):
         super(LocalBuild, self).__init__()
+
+        # we can override member variables defined in GlobalBuildRules
+        self._project_name = "MessageFramework"
+        self._project_namespace = "CWRUBotix"
+        self._default_build_steps = ["setupWorkspace",
+                                     "build",
+                                     "runUnitTests",
+                                     "package",
+                                     "uploadPackagedVersion"]  # MessageFramework specific default build steps

--- a/scripts/GlobalBuildRules.py
+++ b/scripts/GlobalBuildRules.py
@@ -1,4 +1,5 @@
 
+# BUILT IN MODULES
 import inspect
 import os
 import platform
@@ -7,6 +8,9 @@ import subprocess
 import sys
 import traceback
 import _winreg
+
+# PYTHON PROJECT MODULES
+import LocalEnvironment
 
 
 def failExecution(errorMsg):
@@ -293,7 +297,13 @@ class GlobalBuild(object):
         self._project_build_number = "0.0.0.0"
         self._configurations = ["debug", "release"]
         self._build_directory = getDirectory(FileSystemDirectory.WORKING)
+
         # execute local environment
+        projectSpecificEnvVars = {
+            # project specific static environment variables
+        }
+        localEnv = LocalEnvironment.LocalEnvironment(projectSpecificEnvVars)
+        localEnv.injectAllEnvironmentVariables()
 
     # removes previous builds so that this build
     # is a fresh build (on this machine). This

--- a/scripts/LocalEnvironment.py
+++ b/scripts/LocalEnvironment.py
@@ -1,0 +1,52 @@
+
+import platform
+import os
+
+
+class LocalEnvironment(object):
+    def __init__(self, projectSpecificEnvVars={}):
+        self._static_environment_variables = {
+            "C_CACHE_DIR": "" if platform.system() == "Windows" else "",
+            # other static environment variables
+        }
+        self._project_specific_static_env_vars = projectSpecificEnvVars
+
+    def injectStaticEnvironmentVariables(self):
+        print("Injecting static environment variables")
+        env = os.environ
+        for item in self._static_environment_variables.items():
+            env[item[0]] = item[1]
+
+    def injectProjectSpecificEnvironmentVariables(self):
+        print("Injecting project specific environment variables")
+        env = os.environ
+        for item in self._project_specific_static_env_vars.items():
+            env[item[0]] = item[1]
+
+    def injectDynamicEnvironmentVariables(self):
+        env = os.environ
+        toAdd = env.get("DYNAMIC_ENV_VARS_FILE")
+        if toAdd is not None and os.path.exists(toAdd):
+            print("Injecting dynamic environment variables")
+            with open(toAdd) as file:
+                splitLine = None
+                line = 1
+                for line in file:
+                    splitLine = line.split('=')
+                    if len(splitLine) == 2:
+                        env[splitLine[0].trim()] = splitLine[1].trim()
+                    else:
+                        raise Exception("invalid syntax in [%s] at line [%s] (line 1 is beginning of file)" %
+                                        (toAdd, line))
+                    line += 1
+        else:
+            print("For potential environment optimization, consider adding\n" +
+                  "a file of key=value pairs. These will be injected as environment\n" +
+                  "variables unique to this project and will only exist for the runtime\n" +
+                  "of this project")
+
+    def injectAllEnvironmentVariables(self):
+        print("Injecting all environment variables")
+        self.injectStaticEnvironmentVariables()
+        self.injectProjectSpecificEnvironmentVariables()
+        self.injectDynamicEnvironmentVariables()


### PR DESCRIPTION
LocalEnvironment is a way to inject environment variables "safely" into
a build. By "safely," I mean that these injections are temporary. Added
functionality to use LocalEnvironment in GlobalBuildRules and added
default build steps to LocalBuild
