### PR TITLE
Promise to WorkItem interface as well as Continuation Support

### DIFF
--- a/cpp/include/FuturesFramework/IChainLinker.hpp
+++ b/cpp/include/FuturesFramework/IChainLinker.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#ifndef FUTURESFRAMEWORK_ICHAINLINKER_HPP
+#define FUTURESFRAMEWORK_ICHAINLINKER_HPP
+
+// SYSTEM INCLUDES
+#include <memory>
+
+// C++ PROJECT INCLUDES
+#include "FuturesFramework/IWorkItem.hpp"
+#include "FuturesFramework/Result.hpp"
+
+namespace FuturesFramework
+{
+
+	class IChainLinker
+	{
+	protected:
+
+		virtual Types::Result_t ApplyFunctionToChild() = 0;
+	public:
+
+		virtual ~IChainLinker() = default;
+
+		virtual Types::Result_t Chain() = 0;
+
+	};
+
+	using IChainLinkerPtr = std::shared_ptr<IChainLinker>;
+
+}
+
+#endif

--- a/cpp/include/FuturesFramework/IPromiseWorkItem.hpp
+++ b/cpp/include/FuturesFramework/IPromiseWorkItem.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#ifndef FUTURESFRAMEWORK_IPROMISEWORKITEM_HPP
+#define FUTURESFRAMEWORK_IPROMISEWORKITEM_HPP
+
+// SYSTEM INCLUDES
+#include <memory>
+
+// C++ PROJECT INCLUDES
+#include "FuturesFramework/IChainLinker.hpp"
+#include "FuturesFramework/PromiseStates.hpp"
+#include "FuturesFramework/WorkItemStates.hpp"
+
+namespace FuturesFramework
+{
+
+	class IPromiseWorkItem;
+	using IPromiseWorkItemPtr = std::shared_ptr<IPromiseWorkItem>;
+
+	class IPromiseWorkItem
+	{
+	public:
+
+		virtual ~IPromiseWorkItem() = default;
+
+		virtual void SetSuccess() = 0;
+
+		virtual void SetFailure() = 0;
+
+		virtual States::PromiseState GetState() = 0;
+
+		virtual std::string GetInternalStateString() = 0;
+
+		virtual bool IsCurrentlyExecuting() = 0;
+
+		virtual void AddContinuation(IChainLinkerPtr continuation) = 0;
+
+	};
+
+}
+
+
+#endif

--- a/cpp/include/FuturesFramework/PromiseStates.hpp
+++ b/cpp/include/FuturesFramework/PromiseStates.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifndef FUTURESFRAMEWORK_STATES_PROMISESTATES_HPP
+#define FUTURESFRAMEWORK_STATES_PROMISESTATES_HPP
+
+// SYSTEM INCLUDES
+#include <stdexcept>
+#include <string>
+
+// C++ PROJECT INCLUDES
+// (none)
+
+namespace FuturesFramework
+{
+namespace States
+{
+
+	enum class PromiseState
+	{
+		UNTOUCHED = 0,
+		PENDING = 1,
+		SUCCESS = 2,
+		FAILURE = 3,
+	};
+
+} // end of namespace States
+
+std::string GetPromiseStateString(States::PromiseState state);
+
+} // end of namespace FuturesFramework
+
+#endif // end of header guard

--- a/cpp/include/FuturesFramework/PromiseWorkItem.hpp
+++ b/cpp/include/FuturesFramework/PromiseWorkItem.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef FUTURESFRAMEWORK_PROMISEWORKITEM_HPP
+#define FUTURESFRAMEWORK_PROMISEWORKITEM_HPP
+
+// SYSTEM INCLUDES
+#include <vector>
+
+// C++ PROJECT INCLUDES
+#include "FuturesFramework/IPromiseWorkItem.hpp"
+#include "FuturesFramework/WorkItem.hpp"
+
+namespace FuturesFramework
+{
+
+	class PromiseWorkItem;
+	using PromiseWorkItemPtr = std::shared_ptr<PromiseWorkItem>;
+
+	class PromiseWorkItem : public virtual IPromiseWorkItem, public WorkItem
+	{
+	private:
+
+		States::PromiseState			_externalState;
+		std::vector<IChainLinkerPtr>	_chainLinker;
+
+		void SetExternalState(States::PromiseState newState);
+
+		States::WorkItemState GetWorkItemState();
+
+	protected:
+
+		Types::Result_t Execute() override;
+
+	public:
+
+		PromiseWorkItem(): WorkItem(), _externalState(States::PromiseState::UNTOUCHED),
+			_chainLinker()
+		{
+		}
+
+		~PromiseWorkItem()
+		{
+		}
+
+		void SetSuccess() override;
+
+		void SetFailure() override;
+
+		States::PromiseState GetState() override;
+
+		std::string GetStateString() override;
+
+		std::string GetInternalStateString() override;
+
+		bool IsCurrentlyExecuting() override;
+
+		void AddContinuation(IChainLinkerPtr chainLinker) override;
+
+	};
+
+}
+
+
+
+#endif

--- a/cpp/src/FuturesFramework/CMakeLists.txt
+++ b/cpp/src/FuturesFramework/CMakeLists.txt
@@ -49,24 +49,30 @@ set( FUTURESFRAMEWORK_SRCS
     ${SRC_ROOT}/FuturesFramework/WorkItemStateMachine.cpp
     ${SRC_ROOT}/FuturesFramework/Scheduler.cpp
     ${SRC_ROOT}/FuturesFramework/WorkItem.cpp
+    ${SRC_ROOT}/FuturesFramework/PromiseStates.cpp
+    ${SRC_ROOT}/FuturesFramework/PromiseWorkItem.cpp
 )
 
 # Public header files (installed together with libraries)
 set( FUTURESFRAMEWORK_PUBLIC_HEADERS
     ${INC_ROOT}/FuturesFramework/SharedLibExport.hpp
-    ${INC_ROOT}/FuturesFramework/Result.hpp
-    ${INC_ROOT}/FuturesFramework/ScheduleRequestStates.hpp
-    ${INC_ROOT}/FuturesFramework/WorkItemStates.hpp
     ${INC_ROOT}/FuturesFramework/IWorkItemStateMachine.hpp
     ${INC_ROOT}/FuturesFramework/IWorkItem.hpp
     ${INC_ROOT}/FuturesFramework/IExecutable.hpp
     ${INC_ROOT}/FuturesFramework/IScheduler.hpp
+    ${INC_ROOT}/FuturesFramework/IChainLinker.hpp
+    ${INC_ROOT}/FuturesFramework/IPromiseWorkItem.hpp
 )
 
 set( FUTURESFRAMEWORK_PRIVATE_HEADERS
+    ${INC_ROOT}/FuturesFramework/Result.hpp
+    ${INC_ROOT}/FuturesFramework/ScheduleRequestStates.hpp
+    ${INC_ROOT}/FuturesFramework/WorkItemStates.hpp
     ${INC_ROOT}/FuturesFramework/WorkItemStateMachine.hpp
     ${INC_ROOT}/FuturesFramework/Scheduler.hpp
     ${INC_ROOT}/FuturesFramework/WorkItem.hpp
+    ${INC_ROOT}/FuturesFramework/PromiseStates.hpp
+    ${INC_ROOT}/FuturesFramework/PromiseWorkItem.hpp
 )
 
 # setup visual studio source groups

--- a/cpp/src/FuturesFramework/PromiseStates.cpp
+++ b/cpp/src/FuturesFramework/PromiseStates.cpp
@@ -1,0 +1,26 @@
+// SYSTEM INCLUDES
+
+
+// C++ PROJECT INCLUDES
+#include "FuturesFramework/PromiseStates.hpp"
+
+namespace FuturesFramework
+{
+
+	std::string GetPromiseStateString(States::PromiseState state)
+	{
+		switch (state)
+		{
+		case States::PromiseState::UNTOUCHED:
+			return "UNTOUCHED";
+		case States::PromiseState::PENDING:
+			return "PENDING";
+		case States::PromiseState::SUCCESS:
+			return "SUCCESS";
+		case States::PromiseState::FAILURE:
+			return "FAILURE";
+		}
+		throw std::logic_error("Unexpected Promise State");
+	}
+
+}

--- a/cpp/src/FuturesFramework/PromiseWorkItem.cpp
+++ b/cpp/src/FuturesFramework/PromiseWorkItem.cpp
@@ -1,0 +1,81 @@
+// SYSTEM INCLUDES
+
+
+
+// C++ PROJECT INCLUDES
+#include "FuturesFramework/PromiseWorkItem.hpp"
+#include "FuturesFramework/PromiseStates.hpp"
+
+namespace FuturesFramework
+{
+
+	void PromiseWorkItem::SetSuccess()
+	{
+		this->SetExternalState(States::PromiseState::SUCCESS);
+	}
+
+	void PromiseWorkItem::SetFailure()
+	{
+		this->SetExternalState(States::PromiseState::FAILURE);
+	}
+
+	States::WorkItemState PromiseWorkItem::GetWorkItemState()
+	{
+		return this->GetInternalState();
+	}
+
+	void PromiseWorkItem::SetExternalState(States::PromiseState newState)
+	{
+		this->_externalState = newState;
+	}
+
+	States::PromiseState PromiseWorkItem::GetState()
+	{
+		return this->_externalState;
+	}
+
+	std::string PromiseWorkItem::GetStateString()
+	{
+		return GetPromiseStateString(this->_externalState);
+	}
+
+	std::string PromiseWorkItem::GetInternalStateString()
+	{
+		return this->WorkItem::GetStateString();
+	}
+
+	bool PromiseWorkItem::IsCurrentlyExecuting()
+	{
+		return (this->GetInternalState() == States::WorkItemState::EXECUTING_MAIN_FUNCTION ||
+			this->GetInternalState() == States::WorkItemState::EXECUTING_POSTERIOR_FUNCTION) &&
+			(this->GetThreadId() == std::this_thread::get_id());
+	}
+
+	Types::Result_t PromiseWorkItem::Execute()
+	{
+		Types::Result_t result = this->WorkItem::Execute();
+		if (result == Types::Result_t::FAILURE)
+		{
+			// do OnError callback here if it exists.
+		}
+		else if (result == Types::Result_t::SUCCESS)
+		{
+			// do Then callback here if it exists.
+			for (IChainLinkerPtr& successor : this->_chainLinker)
+			{
+				successor->Chain();
+			}
+		}
+
+		// this->SetExternalState(States::PromiseState::UNTOUCHED);
+		// this logic is called!!! If we set the External State to States::PromiseStates::UNTOUCHED
+		// it will return the value we set as well as 
+		return result;
+	}
+
+	void PromiseWorkItem::AddContinuation(IChainLinkerPtr ptr)
+	{
+		this->_chainLinker.push_back(ptr);
+	}
+
+}


### PR DESCRIPTION
Promises are essentially WorkItems. However, WorkItems have to be
general enough for ANYONE to derive, so Promise specific functionality
must be in a derived class. This is the derived class. In this class we
can start to implement more Promise specific code, most importantly with
the continuation aspect. I'm sorry theres no comments on any of this
yet, I'll get on that tomorrow. I have more to commit but I should
probably go to bed as its my last day of work tomorrow.
