### PR TITLE
Concurrency and Promise code unit test change

### DIFF
--- a/cpp/include/FuturesFramework/ConcurrencyStates.hpp
+++ b/cpp/include/FuturesFramework/ConcurrencyStates.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifndef FUTURESFRAMEWORK_STATES_CONCURRENCYSTATES_HPP
+#define FUTURESFRAMEWORK_STATES_CONCURRENCYSTATES_HPP
+
+// SYSTEM INCLUDES
+#include <string>
+
+// C++ PROJECT INCLUDES
+
+
+namespace FuturesFramework
+{
+namespace States
+{
+
+    enum class ConcurrencyState
+    {
+        IDLE = 0,
+        BUSY = 1,
+        DONE = 2,
+    };
+
+} // end of namespace States
+
+std::string GetConcurrencyStateString(const States::ConcurrencyState& state);
+
+} // end of namespace FuturesFramework
+
+#endif

--- a/cpp/include/FuturesFramework/IExecutableWorkItem.hpp
+++ b/cpp/include/FuturesFramework/IExecutableWorkItem.hpp
@@ -9,15 +9,24 @@
 // C++ PROJECT INCLUDES
 #include "FuturesFramework/LibraryExport.hpp"
 #include "FuturesFramework/IWorkItem.hpp"
+// #include "FuturesFramework/WorkerThread.hpp"
 
 // project namespace
 namespace FuturesFramework
 {
-
+namespace Concurrency
+{
+    class WorkerThread;
+}
     // interface to allow IWorkItems to be executable by Schedulers.
     // This interface is exported to clients.
     class FUTURESFRAMEWORK_API IExecutableWorkItem : public IWorkItem
     {
+        friend class Concurrency::WorkerThread;
+    private:
+
+        virtual bool IsDone() = 0;
+
     protected:
 
         // this is the method that an IScheduler calls to run this

--- a/cpp/include/FuturesFramework/IScheduler.hpp
+++ b/cpp/include/FuturesFramework/IScheduler.hpp
@@ -4,15 +4,14 @@
 #define FUTURESFRAMEWORK_ISCHEDULER_HPP
 
 // SYSTEM INCLUDES
-#include <queue>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <thread>
 
 // C++ PROJECT INCLUDES
 #include "FuturesFramework/LibraryExport.hpp"
-#include "FuturesFramework/IWorkItem.hpp"
+#include "FuturesFramework/IExecutableWorkItem.hpp"
+#include "FuturesFramework/IThread.hpp"
 
 // project namespace
 namespace FuturesFramework
@@ -32,9 +31,9 @@ namespace FuturesFramework
 
 	protected:
 
-		virtual std::map<uint64_t, IWorkItemPtr>& GetWorkItemMap() = 0;
+		virtual std::map<uint64_t, IExecutableWorkItemPtr>& GetWorkItemMap() = 0;
 
-		virtual std::map<std::thread::id, std::thread>& GetThreadMap() = 0;
+		virtual std::map<std::thread::id, Concurrency::IThreadPtr>& GetThreadMap() = 0;
 
 		virtual bool DetachWorkItem(uint64_t id) = 0;
 
@@ -42,9 +41,11 @@ namespace FuturesFramework
 
 		virtual ~IScheduler() = default;
 
-		virtual bool ScheduleWorkItem(IWorkItemPtr workItem) = 0;
+		virtual bool ScheduleWorkItem(IExecutableWorkItemPtr workItem) = 0;
 
 		virtual void Run() = 0;
+
+        virtual void Shutdown() = 0;
 
 	};
 

--- a/cpp/include/FuturesFramework/IThread.hpp
+++ b/cpp/include/FuturesFramework/IThread.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#ifndef FUTURESFRAMEWORK_ITHREAD_HPP
+#define FUTURESFRAMEWORK_ITHREAD_HPP
+
+// SYSTEM INCLUDES
+#include <thread>
+
+// C++ PROJECT INCLUDES
+#include "FuturesFramework/Result.hpp"
+#include "FuturesFramework/ConcurrencyStates.hpp"
+#include "FuturesFramework/IExecutableWorkItem.hpp"
+
+// project namespace
+namespace FuturesFramework
+{
+// component namespace
+namespace Concurrency
+{
+
+    class IThread
+    {
+    public:
+        virtual ~IThread() = default;
+
+        virtual std::thread::id GetId() = 0;
+
+        virtual States::ConcurrencyState GetState() = 0;
+
+        virtual Types::Result_t Queue(IExecutableWorkItemPtr workItem) = 0;
+
+        virtual void Join() = 0;
+
+        virtual Types::Result_t Abort() = 0;
+
+        virtual void Run() = 0;
+    };
+
+    using IThreadPtr = std::shared_ptr<IThread>;
+
+} // end of namespace Concurrency
+} // end of namespace FuturesFramework
+
+
+#endif

--- a/cpp/include/FuturesFramework/IWorkItem.hpp
+++ b/cpp/include/FuturesFramework/IWorkItem.hpp
@@ -47,7 +47,6 @@ namespace FuturesFramework
     // executed on an IScheduler.
     class FUTURESFRAMEWORK_API IWorkItem
     {
-
     public:
 
         virtual ~IWorkItem() = default;

--- a/cpp/include/FuturesFramework/Promise.hpp
+++ b/cpp/include/FuturesFramework/Promise.hpp
@@ -117,12 +117,15 @@ namespace FuturesFramework
 
         void AttachMainFunction(std::function<PROMISE_RESULT(ARGS...)> pFunc)
         {
-            this->_unboundFunction = std::move(pFunc);
-            std::dynamic_pointer_cast<IExecutableWorkItem>(this->_internalWorkItem)
-                ->AttachMainFunction([]() -> Types::Result_t
+            if (!this->_unboundFunction)
             {
-                return Types::Result_t::FAILURE;
-            });
+                std::dynamic_pointer_cast<IExecutableWorkItem>(this->_internalWorkItem)
+                    ->AttachMainFunction([]() -> Types::Result_t
+                {
+                    return Types::Result_t::FAILURE;
+                });
+                this->_unboundFunction = std::move(pFunc);
+            }
         }
 
     };

--- a/cpp/include/FuturesFramework/PromiseBase.hpp
+++ b/cpp/include/FuturesFramework/PromiseBase.hpp
@@ -7,7 +7,7 @@
 
 
 // C++ PROJECT INCLUDES
-#include "FuturesFramework/IWorkItem.hpp"
+#include "FuturesFramework/IExecutableWorkItem.hpp"
 #include "FuturesFramework/ContinuableWorkItem.hpp"
 #include "FuturesFramework/LibraryExport.hpp"
 

--- a/cpp/include/FuturesFramework/Scheduler.hpp
+++ b/cpp/include/FuturesFramework/Scheduler.hpp
@@ -4,11 +4,20 @@
 #define FUTURESFRAMEWORK_SCHEDULER_HPP
 
 // SYSTEM INCLUDES
-#include <queue>
+#include <mutex>
+#include <string>
 
 // C++ PROJECT INCLUDES
+#include "FuturesFramework/IExecutableWorkItem.hpp"
 #include "FuturesFramework/IScheduler.hpp"
-#include "FuturesFramework/WorkItem.hpp"
+#include "FuturesFramework/WorkerThread.hpp"
+
+
+// thread max
+#ifndef THREAD_POOL_MAX
+#define THREAD_POOL_MAX 1
+#endif
+
 
 // project namespace
 namespace FuturesFramework
@@ -21,42 +30,59 @@ namespace FuturesFramework
     // a Scheduler. An instance of this will execute IExecutableWorkItems
     // (for now IWorkItems).
 	class Scheduler : public IScheduler,
-        public virtual std::enable_shared_from_this<Scheduler>
+        public std::enable_shared_from_this<Scheduler>
 	{
-	private:
+	private: 
 
 		// global variables
-		std::map<uint64_t, IWorkItemPtr>		_attachedWorkItems;
-		std::mutex								_mutex;
+		std::map<uint64_t, IExecutableWorkItemPtr>	            _attachedWorkItems;
+		std::mutex								                _mutex;
 
 		// thread pool variables
-		std::map<std::thread::id, std::thread>	_threadMap;
+		std::map<std::thread::id, Concurrency::IThreadPtr>      _threadMap;
 
-		uint64_t								_currentWorkItemId;
+		uint64_t								                _currentWorkItemId;
+        // Concurrency::IThreadPtr                                 _tempWorkerThread;
+        bool                                                    _running;
 
 	protected:
 
-		std::map<uint64_t, IWorkItemPtr>& GetWorkItemMap() override;
+		std::map<uint64_t, IExecutableWorkItemPtr>& GetWorkItemMap() override;
 
-		std::map<std::thread::id, std::thread>& GetThreadMap() override;
+		std::map<std::thread::id, Concurrency::IThreadPtr>& GetThreadMap() override;
 
 		bool DetachWorkItem(uint64_t id) override;
+
+        // std::queue<IExecutableWorkItemPtr>& GetQueue();
 
         bool ExecuteWorkItem(const uint64_t id);
 
 	public:
 
-		Scheduler() : _attachedWorkItems(), _mutex(), _currentWorkItemId(0)
+		Scheduler() : _attachedWorkItems(), _mutex(),
+            _threadMap(), _currentWorkItemId(0), _running(false) // ,
+            // _tempWorkerThread(std::make_shared<Concurrency::WorkerThread>())
 		{
+            // std::lock_guard<std::mutex>(this->_mutex);
+            // Concurrency::IThreadPtr pWorkerThread = nullptr;
+            // for (int i = 0; i < THREAD_POOL_MAX; ++i)
+            // {
+            //     pWorkerThread = std::make_shared<Concurrency::WorkerThread>();
+            //     this->_threadMap.insert(std::pair<std::thread::id,
+            //         Concurrency::IThreadPtr>(pWorkerThread->GetId(), pWorkerThread));
+            // }
 		}
 
 		virtual ~Scheduler()
 		{
+            this->Shutdown();
 		}
 
-		bool ScheduleWorkItem(IWorkItemPtr workItem) override;
+		bool ScheduleWorkItem(IExecutableWorkItemPtr workItem) override;
 
 		void Run() override;
+
+        void Shutdown() override;
 
         const uint64_t GetCurrentWorkItemId();
 

--- a/cpp/include/FuturesFramework/WorkItem.hpp
+++ b/cpp/include/FuturesFramework/WorkItem.hpp
@@ -25,15 +25,15 @@ namespace FuturesFramework
 
         uint64_t            _id;
         ISchedulerPtr       _pScheduler;
-        FunctionPtr _pMainFunction;
-        FunctionPtr _pPostFunction;
+        FunctionPtr         _pMainFunction;
+        FunctionPtr         _pPostFunction;
         std::exception_ptr  _pException;
 
     private:
 
         void SetId(uint64_t id);
  
-        bool IsDone();
+        bool IsDone() override;
 
     protected:
 
@@ -64,6 +64,8 @@ namespace FuturesFramework
         const uint64_t GetId() override;
 
         std::exception_ptr GetException() const;
+
+        const std::string GetStateAsString();
 
     };
 

--- a/cpp/include/FuturesFramework/WorkerThread.hpp
+++ b/cpp/include/FuturesFramework/WorkerThread.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#ifndef FUTURESFRAMEWORK_CONCURRENCY_WORKERTHREAD_HPP
+#define FUTURESFRAMEWORK_CONCURRENCY_WORKERTHREAD_HPP
+
+// SYSTEM INCLUDES
+#include <atomic>
+#include <condition_variable>
+#include <queue>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+// C++ PROJECT INCLUDES
+#include "FuturesFramework/IThread.hpp"
+
+namespace FuturesFramework
+{
+namespace Concurrency
+{
+
+    class WorkerThread : public IThread,
+        public std::enable_shared_from_this<WorkerThread>
+    {
+    private:
+
+        // thread variables
+        std::thread                             _thread; // the concurrent thread
+        std::condition_variable                 _threadCV; // allows _thread to sleep when queue is empty
+
+        // state variables
+        std::atomic<States::ConcurrencyState>   _state; // read for testing / status
+        std::atomic<bool>                       _run;      // false when thread is shutting down
+                                                           // should this be modeled using test_and_set()?
+                                                           // is this racey having this "unprotected"?
+
+        std::mutex                              _queueMutex; // protects queue
+        std::queue<IExecutableWorkItemPtr>      _queue; // execution queue
+        uint64_t                                _id;
+
+    private:
+
+        bool IsQueueEmpty();
+
+    public:
+
+        WorkerThread(uint64_t id) : _id(id), _state(States::ConcurrencyState::IDLE),
+            _queueMutex(), _queue(), _run(true), _threadCV()
+        {
+            this->_thread = std::thread(&WorkerThread::Run, this);
+        }
+
+        ~WorkerThread()
+        {
+            if (this->_run)
+            {
+                this->Join();
+            }
+        }
+
+        std::thread::id GetId() override;
+
+        States::ConcurrencyState GetState() override;
+
+        Types::Result_t Queue(IExecutableWorkItemPtr workItem) override;
+
+        void Join() override;
+
+        Types::Result_t Abort() override;
+
+        void Run() override;
+
+
+    };
+
+    using WorkerThreadPtr = std::shared_ptr<WorkerThread>;
+} // end of namespace Concurrency
+} // end of namespace FuturesFramework
+
+#endif

--- a/cpp/src/FuturesFramework/CMakeLists.txt
+++ b/cpp/src/FuturesFramework/CMakeLists.txt
@@ -52,6 +52,7 @@ set( FUTURESFRAMEWORK_SRCS
     ${SRC_ROOT}/FuturesFramework/SettlementStates.cpp
     ${SRC_ROOT}/FuturesFramework/ContinuableWorkItem.cpp
     ${SRC_ROOT}/FuturesFramework/PromiseBase.cpp
+    ${SRC_ROOT}/FuturesFramework/WorkerThread.cpp
 )
 
 # Public header files (installed together with libraries)
@@ -74,6 +75,8 @@ set( FUTURESFRAMEWORK_PRIVATE_HEADERS
     ${INC_ROOT}/FuturesFramework/WorkItem.hpp
     ${INC_ROOT}/FuturesFramework/SettlementStates.hpp
     ${INC_ROOT}/FuturesFramework/ContinuableWorkItem.hpp
+    ${INC_ROOT}/FuturesFramework/IThread.hpp
+    ${INC_ROOT}/FuturesFramework/WorkerThread.hpp
 )
 
 # setup visual studio source groups

--- a/cpp/src/FuturesFramework/ConcurrencyStates.cpp
+++ b/cpp/src/FuturesFramework/ConcurrencyStates.cpp
@@ -1,0 +1,25 @@
+// SYSTEM INCLUDES
+
+
+// C++ PROJECT INCLUDES
+#include "FuturesFramework/ConcurrencyStates.hpp"
+
+namespace FuturesFramework
+{
+
+    std::string GetConcurrencyStateString(const States::ConcurrencyState& state)
+    {
+        switch(state)
+        {
+            case States::ConcurrencyState::IDLE:
+                return "IDLE";
+            case States::ConcurrencyState::BUSY:
+                return "BUSY";
+            case States::ConcurrencyState::DONE:
+                return "DONE";
+            throw std::exception("Unknown State");
+        }
+        return "";
+    }
+
+} // end of namespace FuturesFramework

--- a/cpp/src/FuturesFramework/ContinuableWorkItem.cpp
+++ b/cpp/src/FuturesFramework/ContinuableWorkItem.cpp
@@ -41,6 +41,10 @@ namespace FuturesFramework
 		Types::Result_t result = this->WorkItem::Execute();
 		if (result == Types::Result_t::FAILURE)
 		{
+            if (this->GetException())
+            {
+                this->SetFailure();
+            }
 			// do OnError callback here if it exists.
             for (IChainLinkerPtr& successor : this->_failureSuccessors)
             {

--- a/cpp/src/FuturesFramework/PromiseBase.cpp
+++ b/cpp/src/FuturesFramework/PromiseBase.cpp
@@ -25,7 +25,7 @@ namespace FuturesFramework
     Types::Result_t PromiseBase::Schedule(ISchedulerPtr scheduler)
     {
         if (scheduler->ScheduleWorkItem(
-            std::dynamic_pointer_cast<IWorkItem>(this->_internalWorkItem)))
+            std::dynamic_pointer_cast<IExecutableWorkItem>(this->_internalWorkItem)))
         {
             return Types::Result_t::SUCCESS;
         }

--- a/cpp/src/FuturesFramework/WorkItem.cpp
+++ b/cpp/src/FuturesFramework/WorkItem.cpp
@@ -53,9 +53,11 @@ namespace FuturesFramework
 			try
 			{
 				result = this->_pMainFunction();
+                this->Trigger(result);
 			}
 			catch (...)
 			{
+                this->Trigger(Types::Result_t::SUCCESS);
 				this->SetException(std::current_exception());
 			}
 		}
@@ -98,4 +100,9 @@ namespace FuturesFramework
 		// std::cout << "Exiting WorkItem::Schedule() with state: " << this->WorkItem::GetStateString() << std::endl;
 		return result;
 	}
+
+    const std::string WorkItem::GetStateAsString()
+    {
+        return GetWorkItemStateString(this->GetCurrentState());
+    }
 }

--- a/cpp/src/FuturesFramework/WorkerThread.cpp
+++ b/cpp/src/FuturesFramework/WorkerThread.cpp
@@ -1,0 +1,130 @@
+
+// SYSTEM INCLUDES
+#include <iostream>
+
+// C++ PROJECT INCLUDES
+#include "FuturesFramework/WorkerThread.hpp"
+#include "FuturesFramework/WorkItem.hpp"
+
+namespace FuturesFramework
+{
+namespace Concurrency
+{
+
+    bool WorkerThread::IsQueueEmpty()
+    {
+        std::lock_guard<std::mutex> queueLock(this->_queueMutex);
+        return this->_queue.empty();
+    }
+
+    std::thread::id WorkerThread::GetId()
+    {
+        return this->_thread.get_id();
+    }
+
+    States::ConcurrencyState WorkerThread::GetState()
+    {
+        // std::cout << "Entering WorkerThread[" << this->_id << "]::GetState()" << std::endl;
+        // std::cout << "Exiting WorkerThread[" << this->_id << "]::GetState()" << std::endl;
+        return this->_state;
+    }
+
+    Types::Result_t WorkerThread::Queue(IExecutableWorkItemPtr workItem)
+    {
+        // modifying queue so need to aquire lock on it
+        std::unique_lock<std::mutex> queueLock(this->_queueMutex);
+        this->_queue.push(workItem);
+
+        // wake up the spawned thread if it is sleeping.
+        this->_threadCV.notify_one();
+        queueLock.unlock();
+
+        return Types::Result_t::SUCCESS;
+    }
+
+    void WorkerThread::Join()
+    {
+        this->_run = false;
+
+        // synchronization! This prevents a algorithmic hole in
+        // the second while loop in WorkerThread::Run
+        std::unique_lock<std::mutex> queueLock(this->_queueMutex);
+
+        this->_threadCV.notify_all();
+
+        // MUST unlock! Otherwise, if we try and join with the _thread,
+        // the _thread is waiting for _queueMutex to be released.
+        // if we don't release the lock, we will have a deadlock
+        // (this thread will wait for _thread to exit, while _thread is
+        // waiting for _queueMutex to be unlocked but this thread possesses
+        // a lock on _queueMutex which will never be released)!
+        queueLock.unlock();
+        if (this->_thread.joinable())
+        {
+            this->_thread.join();
+        }
+        this->_state = States::ConcurrencyState::DONE;
+
+    }
+
+    Types::Result_t WorkerThread::Abort()
+    {
+        return Types::Result_t::FAILURE;
+    }
+
+    // this is the method that the concurrent thread (this->_thread) will run.
+    // it will try and get workItems from the queue when there are stuff
+    // to be had, otherwise it will go to sleep to be woken when the
+    // queue is populated.
+    void WorkerThread::Run()
+    {
+        std::cout << "Entering WorkerThread[" << this->_id << "]::Run()" << std::endl;
+        // the work item we will be executing
+        IExecutableWorkItemPtr workItem = nullptr;
+
+        while (this->_run)
+        {
+            std::unique_lock<std::mutex> queueLock(this->_queueMutex);
+            while (this->_run && !this->_queue.empty())
+            {
+
+                // this is atomic
+                this->_state = States::ConcurrencyState::BUSY;
+
+                // lock the queue and retrieve the WorkItem.
+                // this is in its own code block because the lock
+                // is released only when the object destructs.
+                std::cout << "WorkerThread[" << this->_id << "] Getting WorkItem to execute" << std::endl;
+                workItem = this->_queue.front();
+                this->_queue.pop();
+                queueLock.unlock();
+
+                std::cout << "WorkerThread[" << this->_id << "] Executing WorkItem" << std::endl;
+                // execute the WorkItem
+                // DON'T BLOCK HERE....THIS COULD BE VERY EXPENSIVE
+                // BOTH RUNTIME AND RESOURCE WISE
+                workItem->Execute();
+
+                queueLock.lock();
+                // reschedule if necessary
+                if (!workItem->IsDone())
+                {
+                    std::cout << "Rescheduling WorkItem" << std::endl;
+                    this->_queue.push(workItem);
+                }
+            }
+            this->_state = States::ConcurrencyState::IDLE;
+
+            std::cout << "WorkerThread[" << this->_id << "] going to sleep" << std::endl;
+
+            // lock on this thread
+            // put the concurrent thread to sleep until it is woken up by
+            // a WorkItem being queued.
+            this->_threadCV.wait(queueLock);
+            std::cout << "WorkerThread[" << this->_id << "] awoken, ready to do work" << std::endl;
+        }
+        std::cout << "Exiting WorkerThread[" << this->_id << "]::Run()" << std::endl;
+    }
+
+} // end of namespace Concurrency
+} // end of namespace FuturesFramework

--- a/cpp/src/FuturesFramework/unitTest/CMakeLists.txt
+++ b/cpp/src/FuturesFramework/unitTest/CMakeLists.txt
@@ -37,8 +37,7 @@ if( RUN_UNIT_TESTS )
     enable_testing()
     
     list( APPEND CMAKE_FIND_ROOT_PATH ${INSTALL_ROOT} )
-    # include(BringInPackages)  # NOT build in
-    # BringInPackages()
+
     find_package( Catch REQUIRED )
 
     if( CATCH_FOUND )
@@ -61,6 +60,7 @@ if( RUN_UNIT_TESTS )
             ${SRC_ROOT}/../SettlementStates.cpp
             ${SRC_ROOT}/../ContinuableWorkItem.cpp
             ${SRC_ROOT}/../PromiseBase.cpp
+            ${SRC_ROOT}/../WorkerThread.cpp
 
             # FuturesFrameworkUnitTests sources
             ${SRC_ROOT}/catchConfig.cpp
@@ -71,23 +71,12 @@ if( RUN_UNIT_TESTS )
             ${SRC_ROOT}/WorkItemAndScheduler_unit.cpp
             ${SRC_ROOT}/ContinuableWorkItem_unit.cpp
             ${SRC_ROOT}/Promise_unit.cpp
+            ${SRC_ROOT}/WorkerThread_unit.cpp
         )
 
         set( FUTURESFRAMEWORK_UNITTEST_HEADERS
-            # FuturesFramework headers
-            ${INC_ROOT}/Result.hpp
-            ${INC_ROOT}/WorkItemStates.hpp
-            ${INC_ROOT}/WorkItemStateMachine.hpp
-            ${INC_ROOT}/IWorkItem.hpp
-            ${INC_ROOT}/IExecutableWorkItem.hpp
-            ${INC_ROOT}/IScheduler.hpp
-            ${INC_ROOT}/Scheduler.hpp
-            ${INC_ROOT}/WorkItem.hpp
-            ${INC_ROOT}/SettlementStates.hpp
-            ${INC_ROOT}/ContinuableWorkItem.hpp
-            ${INC_ROOT}/PromiseBase.hpp
-            ${INC_ROOT}/IPromise.hpp
-            ${INC_ROOT}/Promise.hpp
+            # apparently we don't need to include FuturesFramework headers.
+            # I assume its because we are not exporting them.
 
             # FuturesFrameworkUnitTests headers
             ${SRC_ROOT}/WorkItemStateMachineUnitTestInterface.hpp

--- a/cpp/src/FuturesFramework/unitTest/ContinuableWorkItem_unit.cpp
+++ b/cpp/src/FuturesFramework/unitTest/ContinuableWorkItem_unit.cpp
@@ -78,6 +78,9 @@ namespace Tests
         REQUIRE( pMockScheduler->
             ExecuteWorkItem(pFailWorkItem->GetId()) );
 
+        REQUIRE( pSuccessWorkItem->GetStateAsString().compare("Done") == 0 );
+        REQUIRE( pFailWorkItem->GetStateAsString().compare("Reschedule") == 0 );
+
         REQUIRE( pMockScheduler->
             DetachWorkItem(pSuccessWorkItem->GetId()) );
         REQUIRE( pMockScheduler->

--- a/cpp/src/FuturesFramework/unitTest/MockScheduler.cpp
+++ b/cpp/src/FuturesFramework/unitTest/MockScheduler.cpp
@@ -10,13 +10,13 @@ namespace FuturesFramework
 namespace Tests
 {
 
-    std::map<uint64_t, IWorkItemPtr>& 
+    std::map<uint64_t, IExecutableWorkItemPtr>& 
         MockScheduler::GetWorkItemMap()
     {
         return this->Scheduler::GetWorkItemMap();
     }
 
-    std::map<std::thread::id, std::thread>& 
+    std::map<std::thread::id, Concurrency::IThreadPtr>& 
         MockScheduler::GetThreadMap()
     {
         return this->Scheduler::GetThreadMap();

--- a/cpp/src/FuturesFramework/unitTest/MockScheduler.hpp
+++ b/cpp/src/FuturesFramework/unitTest/MockScheduler.hpp
@@ -25,9 +25,9 @@ namespace Tests
         {
         }
 
-        std::map<uint64_t, IWorkItemPtr>& GetWorkItemMap();
+        std::map<uint64_t, IExecutableWorkItemPtr>& GetWorkItemMap();
 
-        std::map<std::thread::id, std::thread>& GetThreadMap();
+        std::map<std::thread::id, Concurrency::IThreadPtr>& GetThreadMap();
 
         bool DetachWorkItem(uint64_t id);
 

--- a/cpp/src/FuturesFramework/unitTest/WorkItemAndScheduler_unit.cpp
+++ b/cpp/src/FuturesFramework/unitTest/WorkItemAndScheduler_unit.cpp
@@ -176,26 +176,32 @@ namespace Tests
         REQUIRE( pMockScheduler->
             ExecuteWorkItem(pDoubleThrowWorkItem->GetId()) );
         REQUIRE( pDoubleThrowWorkItem->GetException() != nullptr );
+        REQUIRE( pDoubleThrowWorkItem->GetStateAsString().compare("Done") == 0 );
     
         REQUIRE( pMockScheduler->
             ExecuteWorkItem(pThrowMainWorkItem->GetId()) );
         REQUIRE( pThrowMainWorkItem->GetException() != nullptr );
+        REQUIRE( pThrowMainWorkItem->GetStateAsString().compare("Done") == 0 );
 
         REQUIRE( pMockScheduler->
             ExecuteWorkItem(pThrowPostWorkItem->GetId()) );
         REQUIRE( pThrowPostWorkItem->GetException() == nullptr );
+        REQUIRE( pThrowPostWorkItem->GetStateAsString().compare("Done") == 0 );
 
         REQUIRE( pMockScheduler->
             ExecuteWorkItem(pDoubleFailWorkItem->GetId()) );
         REQUIRE( pDoubleFailWorkItem->GetException() == nullptr );
+        REQUIRE( pDoubleFailWorkItem->GetStateAsString().compare("Reschedule") == 0 );
 
         REQUIRE( pMockScheduler->
             ExecuteWorkItem(pFailMainWorkItem->GetId()) );
         REQUIRE( pFailMainWorkItem->GetException() == nullptr );
+        REQUIRE( pFailMainWorkItem->GetStateAsString().compare("Reschedule") == 0 );
 
         REQUIRE( pMockScheduler->
             ExecuteWorkItem(pFailPostWorkItem->GetId()) );
         REQUIRE( pFailPostWorkItem->GetException() == nullptr );
+        REQUIRE( pFailPostWorkItem->GetStateAsString().compare("Done") == 0 );
         // ----------------------------------------------------
 
         for (unsigned int i = 0; i < idVector.size(); ++i)

--- a/cpp/src/FuturesFramework/unitTest/WorkerThread_unit.cpp
+++ b/cpp/src/FuturesFramework/unitTest/WorkerThread_unit.cpp
@@ -1,0 +1,246 @@
+
+// SYSTEM INCLUDES
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+// C++ PROJECT INCLUDES
+#include "catch/catch.hpp"
+#include "FuturesFramework/ConcurrencyStates.hpp"
+#include "FuturesFramework/WorkerThread.hpp"
+#include "FuturesFramework/Scheduler.hpp"
+
+#include "FuturesFramework/Result.hpp"
+#include "FuturesFramework/WorkItemStates.hpp"
+#include "FuturesFramework/WorkItem.hpp"
+
+#include "FuturesFramework/SettlementStates.hpp"
+#include "FuturesFramework/ContinuableWorkItem.hpp"
+
+#include "FuturesFramework/Promise.hpp"
+
+namespace FuturesFramework
+{
+namespace Tests
+{
+
+    TEST_CASE("Testing WorkerThread default constructor and Shutdown()",
+        "[WorkerThread_unit]")
+    {
+        // construct an object
+        Concurrency::WorkerThread wThread(0);
+
+        // nothing has been executed...so inner thread should be IDLE.
+        REQUIRE( wThread.GetState() == States::ConcurrencyState::IDLE );
+
+        wThread.Join();
+
+        REQUIRE( wThread.GetState() == States::ConcurrencyState::DONE );
+    }
+
+    TEST_CASE("Testing default WorkerThread destructor", "[WorkerThread_unit]")
+    {
+        try
+        {
+            // construct an object
+            Concurrency::WorkerThread wThread(1);
+
+            // nothing has been executed...so inner thread should be IDLE
+            REQUIRE( wThread.GetState() == States::ConcurrencyState::IDLE );
+        }
+        catch(...)
+        {
+            REQUIRE( false );
+        }
+    }
+
+    TEST_CASE("Testing Queue and Execution with WorkItems",
+        "[WorkerThread_unit]")
+    {
+        WorkItemPtr pWorkItem = std::make_shared<WorkItem>();
+
+        Concurrency::WorkerThreadPtr pWorkerThread =
+            std::make_shared<Concurrency::WorkerThread>(2);
+        ISchedulerPtr pScheduler = std::make_shared<Scheduler>();
+
+        pWorkItem->AttachMainFunction([&]() -> Types::Result_t
+        {
+            std::cout << "\tExecuting with State: " << pWorkItem->GetStateAsString().c_str() << std::endl;
+            REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::BUSY );
+            return Types::Result_t::SUCCESS;
+        });
+        REQUIRE( pWorkItem->Schedule(pScheduler) == Types::Result_t::SUCCESS );
+
+        REQUIRE( pWorkerThread->Queue(pWorkItem) == Types::Result_t::SUCCESS );
+
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+
+        REQUIRE( pWorkItem->GetException() == nullptr );
+        REQUIRE( pWorkItem->GetStateAsString().compare("Done") == 0 );
+        REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::IDLE );
+
+    }
+
+    TEST_CASE("Testing Queue and Execution with ContinuableWorkItems",
+        "[WorkerThread_unit]")
+    {
+        ContinuableWorkItemPtr pContinuableWorkItem =
+            std::make_shared<ContinuableWorkItem>();
+
+        Concurrency::WorkerThreadPtr pWorkerThread =
+            std::make_shared<Concurrency::WorkerThread>(3);
+        ISchedulerPtr pScheduler = std::make_shared<Scheduler>();
+
+        pContinuableWorkItem->AttachMainFunction([&]() -> Types::Result_t
+        {
+            std::cout << "\tExecuting with State: " <<
+                pContinuableWorkItem->GetStateAsString().c_str() << std::endl;
+            REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::BUSY );
+            REQUIRE( pContinuableWorkItem->GetState() == States::SettlementState::PENDING );
+            return Types::Result_t::SUCCESS;
+        });
+        REQUIRE( pContinuableWorkItem->Schedule(pScheduler) == Types::Result_t::SUCCESS );
+
+        REQUIRE( pWorkerThread->Queue(pContinuableWorkItem) == Types::Result_t::SUCCESS );
+
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+
+        REQUIRE( pContinuableWorkItem->GetException() == nullptr );
+        REQUIRE( pContinuableWorkItem->GetStateAsString().compare("Done") == 0 );
+        REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::IDLE );
+        
+    }
+
+    TEST_CASE("Testing Queuing and Execution of Unsuccessful WorkItem",
+        "[WorkerThread_unit]")
+    {
+        WorkItemPtr pWorkItem = std::make_shared<WorkItem>();
+
+        Concurrency::WorkerThreadPtr pWorkerThread =
+            std::make_shared<Concurrency::WorkerThread>(4);
+        ISchedulerPtr pScheduler = std::make_shared<Scheduler>();
+
+        pWorkItem->AttachMainFunction([&]() -> Types::Result_t
+        {
+            std::cout << "State: " << pWorkItem->GetStateAsString().c_str() << std::endl;
+            throw std::exception("blah");
+        });
+        REQUIRE( pWorkItem->Schedule(pScheduler) == Types::Result_t::SUCCESS );
+
+        REQUIRE( pWorkerThread->Queue(pWorkItem) == Types::Result_t::SUCCESS );
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        REQUIRE( pWorkItem->GetException() != nullptr );
+        REQUIRE( pWorkItem->GetStateAsString().compare("Done") == 0 );
+        REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::IDLE );
+    }
+
+    TEST_CASE("Testing Queuing and Execution of 5 WorkItems interleaved",
+        "[WorkerThread_unit]")
+    {
+        WorkItemPtr pWorkItem = std::make_shared<WorkItem>();
+
+        Concurrency::WorkerThreadPtr pWorkerThread =
+            std::make_shared<Concurrency::WorkerThread>(5);
+        ISchedulerPtr pScheduler = std::make_shared<Scheduler>();
+
+        // attach function that will Queue 4 more WorkItems for execution
+        pWorkItem->AttachMainFunction([&]() -> Types::Result_t
+        {
+            REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::BUSY );
+
+            WorkItemPtr pWorkItem2 = std::make_shared<WorkItem>();
+            // attach function that will Queue 3 more WorkItems for execution
+            pWorkItem2->AttachMainFunction([&]() -> Types::Result_t
+            {
+                REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::BUSY );
+
+                WorkItemPtr pWorkItem3 = std::make_shared<WorkItem>();
+                // attach function that will Queue 2 more WorkItems for execution
+                pWorkItem3->AttachMainFunction([&]() -> Types::Result_t
+                {
+                    REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::BUSY );
+
+                    WorkItemPtr pWorkItem4 = std::make_shared<WorkItem>();
+                    // attach function that will Queue 1 more WorkItem for execution
+                    pWorkItem4->AttachMainFunction([&]() -> Types::Result_t
+                    {
+                        REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::BUSY );
+
+                        WorkItemPtr pWorkItem5 = std::make_shared<WorkItem>();
+                        // return Success
+                        pWorkItem5->AttachMainFunction([]() -> Types::Result_t
+                        {
+                            return Types::Result_t::SUCCESS;
+                        });
+
+                        REQUIRE( pWorkItem5->Schedule(pScheduler) == Types::Result_t::SUCCESS );
+                        REQUIRE( pWorkerThread->Queue(pWorkItem5) == Types::Result_t::SUCCESS );
+
+                        return Types::Result_t::SUCCESS;
+                       
+                    });
+
+                    REQUIRE( pWorkItem4->Schedule(pScheduler) == Types::Result_t::SUCCESS );
+                    REQUIRE( pWorkerThread->Queue(pWorkItem4) == Types::Result_t::SUCCESS );
+
+                    return Types::Result_t::SUCCESS;
+                });
+                REQUIRE( pWorkItem3->Schedule(pScheduler) == Types::Result_t::SUCCESS );
+                REQUIRE( pWorkerThread->Queue(pWorkItem3) == Types::Result_t::SUCCESS );
+
+                return Types::Result_t::SUCCESS;
+
+            });
+            REQUIRE( pWorkItem2->Schedule(pScheduler) == Types::Result_t::SUCCESS );
+            REQUIRE( pWorkerThread->Queue(pWorkItem2) == Types::Result_t::SUCCESS );
+
+            return Types::Result_t::SUCCESS;
+        });
+        REQUIRE( pWorkItem->Schedule(pScheduler) == Types::Result_t::SUCCESS );
+
+        REQUIRE( pWorkerThread->Queue(pWorkItem) == Types::Result_t::SUCCESS );
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::IDLE );
+    }
+
+    TEST_CASE("Stress test Queuing and Execution of WorkItems", "[WorkerThread_unit]")
+    {
+        int stressLimit = 100;
+        std::vector<WorkItemPtr> queuedWorkItems;
+
+        ISchedulerPtr pScheduler = std::make_shared<Scheduler>();
+
+        Concurrency::WorkerThreadPtr pWorkerThread =
+            std::make_shared<Concurrency::WorkerThread>(6);
+
+        for(int i = 0; i < stressLimit; ++i)
+        {
+            WorkItemPtr pWorkItem = std::make_shared<WorkItem>();
+            pWorkItem->AttachMainFunction([]() -> Types::Result_t
+            {
+                return Types::Result_t::SUCCESS;
+            });
+
+            queuedWorkItems.push_back(pWorkItem);
+
+            REQUIRE( pWorkItem->Schedule(pScheduler) == Types::Result_t::SUCCESS );
+            REQUIRE( pWorkerThread->Queue(pWorkItem) == Types::Result_t::SUCCESS );
+        }
+
+        std::this_thread::sleep_for(std::chrono::seconds(4));
+
+        for(int i = 0; i < stressLimit; ++i)
+        {
+            REQUIRE( queuedWorkItems[i]->GetStateAsString().compare("Done") == 0 );
+        }
+
+        REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::IDLE );
+    }
+
+} // end of namespace Tests
+} // end of namespace FuturesFramework

--- a/manual/forDevelopers/Concurrency.txt
+++ b/manual/forDevelopers/Concurrency.txt
@@ -1,0 +1,349 @@
+
+So...concurrency.
+
+
+The back end of our FuturesFramework (not exported for clients), is grouped by two
+properties:
+
+1)  Separating execution threads by Node type.
+    Let's assume that you have different "types" of jobs that
+    you want to run in parallel. These are referred to as
+    "Nodes," and each "Node" will have its own set of execution threads.
+    The data structure corresponding to these are known as Schedulers
+
+2)  Separating execution threads by Priority.
+    Let's assume that within you "Node," you have different
+    types of "Node jobs" that you want to execute differently,
+    aka have different priorities. Each "Node" will have
+    a set of worker threads that will execute jobs concurrently,
+    with each worker thread corresponding to a different "Node job priority."
+    The data structure corresponding to these are known as WorkerThreads.
+
+A Scheduler will have the following (shared data):
+    - std::map<uint64_t, IExecutableWorkItemPtr>
+        This is a map of where ALL submitted WorkItems will be stored.
+        This is not indicitive of the execution order, but instead keeps
+        track of all WorkItems during their lifetimes.
+        Therefore, since this data is shared with the WorkerThreads,
+        it will have a mutex protecting it.
+
+A WorkerThread will have the following (shared data):
+    It is important to note that a WorkerThread internally spawns a thread
+    that will run concurrently. This thread will call the WorkerThread::Run()
+    method. All shared data here is shared with the concurrent thread.
+
+    - std::queue<IExecutableWorkItemPtr>
+        This is the execution queue for the WorkerThread. It determines
+        the order in which WorkItems are executed. This is protected
+        by a mutex.
+
+    - std::thread
+        This is the concurrent thread. It has its own mutex (and a condition variable
+        to allow it to sleep when there is nothing in the queue). This needs
+        a mutex for the condition variable to work, although I only see it
+        being owned by the thread itself.
+
+
+    here is the pseudo-algorithm that the concurrent thread will run:
+
+    while( not shutdown ):
+        aquire thread lock;
+        while( the queue is not empty AND not shutdown ):
+            set state of WorkerThread to BUSY;
+
+            aquire lock on queue;
+            WorkItem w = queue.dequeue();
+            release the lock on the queue;
+
+            w.Execute();
+
+            if( the workItem needs to be rescheduled ):
+                aquire lock on queue;
+                queue.push(w);
+                release lock on queue;
+            endif;
+        endwhile;
+
+        set state of WorkerThread to IDLE:
+        put the thread to sleep until woken;
+    endwhile;
+
+    what do you think?
+    The shutdown variable and the state of the WorkerThread are (bool, States::ConcurrencyState).
+    Should they be protected by synchronization constructs? I can have the shutdown boolean
+    given a mutex and try to prevent the case where the WorkerThread is told to shutdown WHILE
+    the second while loop condition is being evaluating (was paused) in such a way that shutdown
+    was ALREADY stored locally (was not told to shutdown yet), and then resumed. The worst case is
+    that only 1 more work item at max would be executed. AND, if i were to put a lock around that,
+    how would I release that lock? I don't want to hold it for the duration of the entire loop, and
+    I don't want to put a "break" line in there.
+
+
+Random thing:
+Shutdown calls
+        this->_threadCV.notify_all();
+        this->Join();
+and Join() is:
+        this->_threadCV.notify_all();
+        this->_thread.join();
+Is it intentional to repeat this->_threadCV.notify_all()?
+
+One other question that might be stupid:
+	Can a thread call the shutdown function for another thread? Because if it can't (or you could prohibit it)
+	You wouldn't have to worry about undefined behavior when multiple functions act on the same thread
+
+I know you changed to actual variable to it, but I don't really see what shifting if from the right side of &&
+to the left side does in terms of benifits. I am aware of the behavior (if the first part is false, it doesn't evaluate the second)
+But wouldn't it cause the same issue if the boolean was changed while it was evaluating the second condition in the &&
+You could probably avoid this issue though by doing something like
+while(!_shutdown && !this->.isQueueEmpty() && !_shutdown)
+{
+...
+}
+as long as the compiler didn't optimize that out
+
+if you don't want the shutdown function to run while the loop condition is getting checked, you could do something like
+
+int i = 0;
+while(condition)
+{
+bool can_shutdown = true;
+if(i != 0)
+{
+whatever you want to do
+}
+i = 1;
+bool can_shutdown = false;
+}
+
+For me at least, I think a bigger issue would be if the _shutdown was true but the shutdown function hadn't notified stuff
+with the this->_threadCV.notify_all(); yet
+
+I'm not super familiar with mutex's, so there might be a better way to do them with those, but if you wanted the shutdown function
+and a part of the loop to be mutually exclusive, you could do something like  
+
+while(condition)
+{
+	this->can_shutdown = true
+	
+	if(this->attempting_shutdown) 	 //to avoid race condition between evaluating while loop condition and setting is_shutting_down to true
+	{
+		brief pause		 //pause for race condition, same deal as above
+		while(this->is_shutting_down)
+		{
+		empty loop
+		}
+		...
+	this->can_shutdown = false
+	} 
+}
+
+void WokerThread::Shutdown()
+{
+	this->attempting_shutdown = true
+	while(!this->can_shutdown)
+	{
+	empty loop
+	}
+	this->is_shutting_down = true
+	...
+	this->is_shutting_down = false
+	this->attempting_shutdown = false
+}
+
+if you wanted to avoid wasting cpu cycles on infinite loops, you could add a (probably very) small pause between each loop execution
+but I think the whole thing will be very brief anyways so this won't be a big deal
+
+this would blow up if something like this happened though. It will almost certainly be avoided though
+
+can_shutdown = false
+...
+shutdown
+...
+can_shutdown = true
+
+I hope this is helpful in some way. Sorry if I sound like an idiot :)
+If you have anything else you want me to check out in particular, let me know.
+
+
+===============================COMMENTS 1/6/2016=====================================
+
+ANDREW (3:21 PM) --------------------------------------------------
+
+So, loops in general are really bad because they waste CPU cycles. Even adding a pause in the loop
+still leads to too many wasted CPU cycles in the case where the state of the loop doesn't change
+for long periods of time.
+
+Mutexes are a type of concurrency object known as a "semaphore". A semaphore is a variable that all operations
+on are atomic...meaning that all operations take at most one CPU cycle, OR that the CPU cannot do any
+context switching DURING the operation. Semaphores are integer variables, and programs either "wait()" or
+"signal()" them. The idea is that the "wait()" operation DECREMENTS the semaphore, and if the value is <= 0
+AFTER decrementing, the calling thread is put to sleep and stored in a queue internal to the semaphore.
+When "signal()" is called, the semaphore value is INCREMENTED, and if the value is > 0 AFTER incrementing, the
+first sleeping thread in the semaphore's queue is woken up and resumes execution.
+
+Mutex is a BINARY semaphore, so it can only have the states 0 and 1, and is used for mutal exclusion. Anyone
+trying to take ownership of a std::mutex in C++ has to call (in our case: std::lock_guard or std::unique_lock).
+Both of these instances call "lock()" (which is effectively "wait()" for semaphores), and when destructed,
+call "unlock()" (which is "signal()"). The difference is that std::unique_lock exposes "unlock()" and "lock()"
+while std::lock_guard does not (it assumes you WANT to possess ownership of the lockable object (in our case
+std::mutex) UNTIL the destruction of the std::lock_guard). C++ does not have built in semaphores, which is good
+because they suck and are hard to coordinate.
+
+We have currently the following relevant code for our concurrency:
+
+bool WorkerThread::IsQueueEmpty()
+{
+    std::lock_guard<std::mutex> queueLock(this->_queueMutex);
+    return this->_queue.empty();
+}
+
+void WorkerThread::Shutdown()
+{
+    // is this racey? Can checking this in WorkerThread::Run()
+    // be paused mid check? I'm not sure if checking _shutdown
+    // can be "paused" and then this to be "set," or the reverse
+    // from happening.
+    this->_shutdown = true;
+
+    {
+        // synchronization! This prevents a algorithmic hole in
+        // the second while loop in WorkerThread::Run
+        std::lock_guard<std::mutex> threadLock(this->_threadMutex);
+
+        // really is notifying this->_thread if it is asleep
+        // but .notify_all() is safer than calling notify_one()
+        // in this context
+        this->_threadCV.notify_all();
+    }
+    this->Join();
+}
+
+void WorkerThread::Join()
+{
+    {
+        // synchronization! This prevents a algorithmic hole in
+        // the second while loop in WorkerThread::Run
+        std::lock_guard<std::mutex> threadLock(this->_threadMutex);
+        this->_threadCV.notify_all();
+    }
+    this->_thread.join();
+}
+
+// this is the method that the concurrent thread (this->_thread) will run.
+// it will try and get workItems from the queue when there are stuff
+// to be had, otherwise it will go to sleep to be woken when the
+// queue is populated.
+void WorkerThread::Run()
+{
+    // the work item we will be executing
+    IExecutableWorkItemPtr workItem = nullptr;
+
+    while (!this->_shutdown)
+    {
+        // lock on this thread
+        std::unique_lock<std::mutex> threadLock(this->_threadMutex);
+
+        // !this->_shutdown is here in case we want to terminate
+        // execution while items are in the queue.
+        while (!this->_shutdown && !this->IsQueueEmpty())
+        {
+
+            // this is atomic
+            this->_state = States::ConcurrencyState::BUSY;
+
+            // lock the queue and retrieve the WorkItem.
+            // this is in its own code block because the lock
+            // is released only when the object destructs.
+            {
+                std::lock_guard<std::mutex> queueLock(this->_queueMutex);
+                std::cout << "Getting WorkItem to execute" << std::endl;
+                workItem = this->_queue.front();
+                this->_queue.pop();
+            }
+            threadLock.unlock();
+
+            // execute the WorkItem
+            // DON'T BLOCK HERE....THIS COULD BE VERY EXPENSIVE
+            // BOTH RUNTIME AND RESOURCE WISE
+            workItem->Execute();
+
+            threadLock.lock();
+            // reschedule if necessary
+            if (!workItem->IsDone())
+            {
+                std::lock_guard<std::mutex> queueLock(this->_queueMutex);
+                this->_queue.push(workItem);
+            }
+        }
+        this->_state = States::ConcurrencyState::IDLE;
+
+        // put the concurrent thread to sleep until it is woken up by
+        // a WorkItem being queued.
+        this->_threadCV.wait(threadLock);
+    }
+    this->_state = States::ConcurrencyState::DONE;
+    std::cout << "Exiting WorkerThread::Run()" << std::endl;
+}
+
+
+The tricky part is this:
+	At any point during the execution of WorkerThread::Run() which is executed
+	ON ANOTHER THREAD running concurrently, the CPU could pause its execution,
+	and begin executing another thread WHICH MIGHT BE CALLING WorkerThread::Shutdown(),
+	WorkerThread::Join() and WorkerThread::IsQueueEmpty() (for now, we will have
+	WorkerThread::Queue() and WorkerThread::Abort() soon).
+
+The design is that WorkerThread::Run() is responsible for actually executing the
+WorkItems while the other threads in existence are responsible for GIVING a WorkerThread
+WorkItems to execute, and for STARTING and SHUTTING DOWN WorkerThreads. Other than that,
+the WorkerThread does its thing and does not interact with any other threads.
+
+I should mention that I changed _shutdown to be std::atomic<bool>.
+This means that setting or reading from _shutdown is an atomic operation.
+
+The usage of the condition variable is to put the thread which WorkerThread::Run()
+executes on to sleep while there are no WorkItems for it to execute. We could make
+our own clunky semaphore classes using a std::mutex, and integer, and a condition variable
+if we wanted, but that wouldn't be worth our time.
+
+The ordering of the second while loop is important was important
+because I was not taking ownership of the queue mutex when calling std::queue.empty().
+This meant that the CPU COULD pause execution of WorkerThread::Run() WHEN THE
+QUEUE WAS EMPTY AND WHEN WorkerThread::Run() WAS EXECUTING std::queue.empty().
+When the CPU resumed execution of another thread, that thread COULD be adding a WorkItem
+to the Queue, and it was possible for that Queue() method to succeed. Then, when
+WorkerThread::Run() was resumed, it would be possible for std::queue.empty() to be TRUE
+AND THERE TO BE SOMETHING IN THE QUEUE! WorkerThread::Run() would go to sleep AND WOULD
+NOT BE WOKEN because the Queue() method could have finished executing and already
+have called std::condition_variable.notify_one(). That means that the WorkerThread::Run()
+thread would be asleep UNTIL a call to shutdown was made, or ANOTHER WorkItem was Queued.
+However, I believe that I have fixed this issue.
+
+In the above scenario, now, WorkerThread::IsQueueEmpty() is used to replace std::queue.empty().
+In WorkerThread::IsQueueEmpty(), the calling thread tries to take ownership of the Queue
+mutex. If it has it, then great, the Queue CANNOT BE MODIFIED by other thread UNTIL
+the mutex is released. Additionally, the thread sleeping synchronization I think
+is fixed too: now the std::condition_variable.notify_one() is protected by trying
+to take ownership of the thread mutex. In the scenario above, it was not, so now if
+this->IsQueueEmpty() returns TRUE BUT a WorkItem is added JUST AFTER WorkerThread::IsQueueEmpty()
+finished (when the lock is released), the thread still will go to sleep BEFORE the call
+to std::condition_variable.notify_one() is made because WorkerThread::Run() has ownership
+of the thread mutex, and releases it ONLY WHEN GOING TO SLEEP. Then, std::condition_variable.notify_one()
+is made and the thread is woken up and reevaluates the loop.
+
+Can you try and find any cases in which the algorithm above breaks? The cases
+where it would break usually are around where the locks are created and released
+if they exist. The thought process is generally "if this part of the code is executed, and then
+paused, and ANOTHER thread comes in and does THIS, what happens?"
+
+Also, in WorkerThread::Shutdown() and WorkerThread::Join(), the redundant call
+to std::condition_variable.notify_all() is necessary because BOTH methods
+are exposed as public (can be called by outside code). Fortunatley, if there are no threads
+waiting on the condition variable, the notify_all() call does nothing.
+
+
+------------------------------------------------------------
+
+
+============================================================================================


### PR DESCRIPTION
Now we have worker threads!!! These guys will actually do the work! This
was the last really difficult thing to do for FuturesFramework....now we
just have to pack it all together so that clients have an entry point
into it, create continuations for Promises, and we're all set for the
basic functionality! MessageFramework can begin using it as a client!
