### PR TITLE
Thread pool functionality

### DIFF
--- a/cpp/include/FuturesFramework/ContinuableWorkItem.hpp
+++ b/cpp/include/FuturesFramework/ContinuableWorkItem.hpp
@@ -4,6 +4,7 @@
 #define FUTURESFRAMEWORK_CONTINUABLEWORKITEM_HPP
 
 // SYSTEM INCLUDES
+#include <atomic>
 #include <vector>
 
 // C++ PROJECT INCLUDES
@@ -30,9 +31,9 @@ namespace FuturesFramework
 
         // how did the ContinuableWorkItem resolve? This is dependent
         // upon which successors will be executed.
-        States::SettlementState         _state;
-        std::vector<IChainLinkerPtr>    _successSuccessors;
-        std::vector<IChainLinkerPtr>    _failureSuccessors;
+        std::atomic<States::SettlementState>    _state;
+        std::vector<IChainLinkerPtr>            _successSuccessors;
+        std::vector<IChainLinkerPtr>            _failureSuccessors;
 
     private:
 

--- a/cpp/include/FuturesFramework/IScheduler.hpp
+++ b/cpp/include/FuturesFramework/IScheduler.hpp
@@ -12,6 +12,7 @@
 #include "FuturesFramework/LibraryExport.hpp"
 #include "FuturesFramework/IExecutableWorkItem.hpp"
 #include "FuturesFramework/IThread.hpp"
+#include "FuturesFramework/JobPriorities.hpp"
 
 // project namespace
 namespace FuturesFramework
@@ -33,7 +34,7 @@ namespace FuturesFramework
 
 		virtual std::map<uint64_t, IExecutableWorkItemPtr>& GetWorkItemMap() = 0;
 
-		virtual std::map<std::thread::id, Concurrency::IThreadPtr>& GetThreadMap() = 0;
+		virtual std::map<Types::JobPriority, Concurrency::IThreadPtr>& GetThreadMap() = 0;
 
 		virtual bool DetachWorkItem(uint64_t id) = 0;
 
@@ -42,8 +43,6 @@ namespace FuturesFramework
 		virtual ~IScheduler() = default;
 
 		virtual bool ScheduleWorkItem(IExecutableWorkItemPtr workItem) = 0;
-
-		virtual void Run() = 0;
 
         virtual void Shutdown() = 0;
 

--- a/cpp/include/FuturesFramework/IThread.hpp
+++ b/cpp/include/FuturesFramework/IThread.hpp
@@ -36,7 +36,7 @@ namespace Concurrency
         virtual void Run() = 0;
     };
 
-    using IThreadPtr = std::shared_ptr<IThread>;
+    using IThreadPtr = std::unique_ptr<IThread>;
 
 } // end of namespace Concurrency
 } // end of namespace FuturesFramework

--- a/cpp/include/FuturesFramework/JobPriorities.hpp
+++ b/cpp/include/FuturesFramework/JobPriorities.hpp
@@ -1,0 +1,24 @@
+
+#ifndef FUTURESFRAMEWORK_TYPES_JOBPRIORITIES_HPP
+#define FUTURESFRAMEWORK_TYPES_JOBPRIORITIES_HPP
+
+// SYSTEM INCLUDES
+
+
+// C++ PROJECT INCLUDES
+
+
+namespace FuturesFramework
+{
+namespace Types
+{
+    enum class JobPriority
+    {
+        IMMEDIATE = 0,
+        RELAXED = 1,
+        OTHER = 2,
+    };
+}
+}
+
+#endif

--- a/cpp/include/FuturesFramework/PromiseBase.hpp
+++ b/cpp/include/FuturesFramework/PromiseBase.hpp
@@ -4,7 +4,7 @@
 #define FUTURESFRAMEWORK_PROMISEBASE_HPP
 
 // SYSTEM INCLUDES
-
+#include <mutex>
 
 // C++ PROJECT INCLUDES
 #include "FuturesFramework/IExecutableWorkItem.hpp"
@@ -26,6 +26,7 @@ namespace FuturesFramework
         // of the internal representation from the external methods
         // available to clients.
         ContinuableWorkItemPtr _internalWorkItem;
+        std::mutex             _executionMutex; // protects GiveArgs() from Execute()
 
     protected:
 

--- a/cpp/include/FuturesFramework/WorkItem.hpp
+++ b/cpp/include/FuturesFramework/WorkItem.hpp
@@ -8,6 +8,7 @@
 
 // C++ PROJECT INCLUDES
 #include "FuturesFramework/IExecutableWorkItem.hpp"
+#include "FuturesFramework/JobPriorities.hpp"
 #include "FuturesFramework/Scheduler.hpp"
 #include "FuturesFramework/WorkItemStateMachine.hpp"
 
@@ -28,6 +29,7 @@ namespace FuturesFramework
         FunctionPtr         _pMainFunction;
         FunctionPtr         _pPostFunction;
         std::exception_ptr  _pException;
+        Types::JobPriority  _jobPriority;
 
     private:
 
@@ -45,8 +47,9 @@ namespace FuturesFramework
 
     public:
 
-        WorkItem(uint64_t id=0) : WorkItemStateMachine(States::WorkItemState::IDLE),
-            _id(id), _pScheduler(nullptr), _pMainFunction(nullptr),
+        WorkItem(uint64_t id=0, Types::JobPriority priority=Types::JobPriority::OTHER) :
+            WorkItemStateMachine(States::WorkItemState::IDLE), _id(id),
+            _jobPriority(priority), _pScheduler(nullptr), _pMainFunction(nullptr),
             _pPostFunction(nullptr), _pException(nullptr)
         {
         }
@@ -66,6 +69,8 @@ namespace FuturesFramework
         std::exception_ptr GetException() const;
 
         const std::string GetStateAsString();
+
+        const Types::JobPriority GetPriority();
 
     };
 

--- a/cpp/include/FuturesFramework/WorkerThread.hpp
+++ b/cpp/include/FuturesFramework/WorkerThread.hpp
@@ -13,6 +13,7 @@
 
 // C++ PROJECT INCLUDES
 #include "FuturesFramework/IThread.hpp"
+#include "FuturesFramework/JobPriorities.hpp"
 
 namespace FuturesFramework
 {
@@ -36,7 +37,6 @@ namespace Concurrency
 
         std::mutex                              _queueMutex; // protects queue
         std::queue<IExecutableWorkItemPtr>      _queue; // execution queue
-        uint64_t                                _id;
 
     private:
 
@@ -44,7 +44,8 @@ namespace Concurrency
 
     public:
 
-        WorkerThread(uint64_t id) : _id(id), _state(States::ConcurrencyState::IDLE),
+        WorkerThread() :
+            _state(States::ConcurrencyState::IDLE),
             _queueMutex(), _queue(), _run(true), _threadCV()
         {
             this->_thread = std::thread(&WorkerThread::Run, this);
@@ -73,7 +74,7 @@ namespace Concurrency
 
     };
 
-    using WorkerThreadPtr = std::shared_ptr<WorkerThread>;
+    using WorkerThreadPtr = std::unique_ptr<WorkerThread>;
 } // end of namespace Concurrency
 } // end of namespace FuturesFramework
 

--- a/cpp/src/FuturesFramework/WorkItem.cpp
+++ b/cpp/src/FuturesFramework/WorkItem.cpp
@@ -105,4 +105,9 @@ namespace FuturesFramework
     {
         return GetWorkItemStateString(this->GetCurrentState());
     }
+
+    const Types::JobPriority WorkItem::GetPriority()
+    {
+        return this->_jobPriority;
+    }
 }

--- a/cpp/src/FuturesFramework/WorkerThread.cpp
+++ b/cpp/src/FuturesFramework/WorkerThread.cpp
@@ -24,8 +24,6 @@ namespace Concurrency
 
     States::ConcurrencyState WorkerThread::GetState()
     {
-        // std::cout << "Entering WorkerThread[" << this->_id << "]::GetState()" << std::endl;
-        // std::cout << "Exiting WorkerThread[" << this->_id << "]::GetState()" << std::endl;
         return this->_state;
     }
 
@@ -78,7 +76,6 @@ namespace Concurrency
     // queue is populated.
     void WorkerThread::Run()
     {
-        std::cout << "Entering WorkerThread[" << this->_id << "]::Run()" << std::endl;
         // the work item we will be executing
         IExecutableWorkItemPtr workItem = nullptr;
 
@@ -94,12 +91,10 @@ namespace Concurrency
                 // lock the queue and retrieve the WorkItem.
                 // this is in its own code block because the lock
                 // is released only when the object destructs.
-                std::cout << "WorkerThread[" << this->_id << "] Getting WorkItem to execute" << std::endl;
                 workItem = this->_queue.front();
                 this->_queue.pop();
                 queueLock.unlock();
 
-                std::cout << "WorkerThread[" << this->_id << "] Executing WorkItem" << std::endl;
                 // execute the WorkItem
                 // DON'T BLOCK HERE....THIS COULD BE VERY EXPENSIVE
                 // BOTH RUNTIME AND RESOURCE WISE
@@ -109,21 +104,17 @@ namespace Concurrency
                 // reschedule if necessary
                 if (!workItem->IsDone())
                 {
-                    std::cout << "Rescheduling WorkItem" << std::endl;
                     this->_queue.push(workItem);
                 }
             }
             this->_state = States::ConcurrencyState::IDLE;
 
-            std::cout << "WorkerThread[" << this->_id << "] going to sleep" << std::endl;
 
             // lock on this thread
             // put the concurrent thread to sleep until it is woken up by
             // a WorkItem being queued.
             this->_threadCV.wait(queueLock);
-            std::cout << "WorkerThread[" << this->_id << "] awoken, ready to do work" << std::endl;
         }
-        std::cout << "Exiting WorkerThread[" << this->_id << "]::Run()" << std::endl;
     }
 
 } // end of namespace Concurrency

--- a/cpp/src/FuturesFramework/unitTest/ContinuableWorkItem_unit.cpp
+++ b/cpp/src/FuturesFramework/unitTest/ContinuableWorkItem_unit.cpp
@@ -1,5 +1,6 @@
 // SYSTEM INCLUDES
-
+#include <chrono>
+#include <iostream>
 
 // C++ PROJECT INCLUDES
 #include "catch/catch.hpp"
@@ -13,8 +14,7 @@ namespace FuturesFramework
 namespace Tests
 {
 
-    TEST_CASE("Testing ContinuableWorkItem default constructor",
-        "[ContinuableWorkItem_unit]")
+    TEST_CASE("Testing ContinuableWorkItem default constructor", "[ContinuableWorkItem_unit]")
     {
         ContinuableWorkItem workItem;
 
@@ -23,8 +23,7 @@ namespace Tests
         REQUIRE( !workItem.IsCurrentlyExecuting() );
     }
 
-    TEST_CASE("Testing ContinuableWorkItem SetSuccess()",
-        "[ContinuableWorkItem_unit]")
+    TEST_CASE("Testing ContinuableWorkItem SetSuccess()", "[ContinuableWorkItem_unit]")
     {
         ContinuableWorkItem workItem;
 
@@ -33,8 +32,7 @@ namespace Tests
             States::SettlementState::SUCCESS );
     }
 
-    TEST_CASE("Testing ContinuableWorkItem SetFailure()",
-        "[ContinuableWorkItem_unit]")
+    TEST_CASE("Testing ContinuableWorkItem SetFailure()", "[ContinuableWorkItem_unit]")
     {
         ContinuableWorkItem workItem;
 
@@ -43,8 +41,7 @@ namespace Tests
             States::SettlementState::FAILURE );
     }
 
-    TEST_CASE("Testing ContinuableWorkItem execution",
-        "[ContinuableWorkItem_unit]")
+    TEST_CASE("Testing ContinuableWorkItem execution", "[ContinuableWorkItem_unit]")
     {
         MockSchedulerPtr pMockScheduler =
             std::make_shared<MockScheduler>();
@@ -62,7 +59,7 @@ namespace Tests
         auto pFailFunction = [&]() -> Types::Result_t
         {
             REQUIRE( pFailWorkItem->IsCurrentlyExecuting() );
-            return Types::Result_t::FAILURE;
+            throw std::exception("blah");
         };
 
         pSuccessWorkItem->AttachMainFunction(pSuccessFunction);
@@ -73,13 +70,11 @@ namespace Tests
         REQUIRE( pFailWorkItem->Schedule(pMockScheduler) ==
             Types::Result_t::SUCCESS );
 
-        REQUIRE( pMockScheduler->
-            ExecuteWorkItem(pSuccessWorkItem->GetId()) );
-        REQUIRE( pMockScheduler->
-            ExecuteWorkItem(pFailWorkItem->GetId()) );
+        std::cout << "Sleeping for 1 second to allow execution" << std::endl;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
 
         REQUIRE( pSuccessWorkItem->GetStateAsString().compare("Done") == 0 );
-        REQUIRE( pFailWorkItem->GetStateAsString().compare("Reschedule") == 0 );
+        REQUIRE( pFailWorkItem->GetStateAsString().compare("Done") == 0 );
 
         REQUIRE( pMockScheduler->
             DetachWorkItem(pSuccessWorkItem->GetId()) );

--- a/cpp/src/FuturesFramework/unitTest/MockScheduler.cpp
+++ b/cpp/src/FuturesFramework/unitTest/MockScheduler.cpp
@@ -10,14 +10,12 @@ namespace FuturesFramework
 namespace Tests
 {
 
-    std::map<uint64_t, IExecutableWorkItemPtr>& 
-        MockScheduler::GetWorkItemMap()
+    std::map<uint64_t, IExecutableWorkItemPtr>& MockScheduler::GetWorkItemMap()
     {
         return this->Scheduler::GetWorkItemMap();
     }
 
-    std::map<std::thread::id, Concurrency::IThreadPtr>& 
-        MockScheduler::GetThreadMap()
+    std::map<Types::JobPriority, Concurrency::IThreadPtr>& MockScheduler::GetThreadMap()
     {
         return this->Scheduler::GetThreadMap();
     }
@@ -25,11 +23,6 @@ namespace Tests
     bool MockScheduler::DetachWorkItem(uint64_t id)
     {
         return this->Scheduler::DetachWorkItem(id);
-    }
-
-    bool MockScheduler::ExecuteWorkItem(const uint64_t id)
-    {
-        return this->Scheduler::ExecuteWorkItem(id);
     }
 
 } // end of namespace Tests

--- a/cpp/src/FuturesFramework/unitTest/MockScheduler.hpp
+++ b/cpp/src/FuturesFramework/unitTest/MockScheduler.hpp
@@ -27,11 +27,9 @@ namespace Tests
 
         std::map<uint64_t, IExecutableWorkItemPtr>& GetWorkItemMap();
 
-        std::map<std::thread::id, Concurrency::IThreadPtr>& GetThreadMap();
+        std::map<Types::JobPriority, Concurrency::IThreadPtr>& GetThreadMap();
 
         bool DetachWorkItem(uint64_t id);
-
-        bool ExecuteWorkItem(const uint64_t id);
     };
 
 } // end of namespace Tests

--- a/cpp/src/FuturesFramework/unitTest/Promise_unit.cpp
+++ b/cpp/src/FuturesFramework/unitTest/Promise_unit.cpp
@@ -1,5 +1,6 @@
 // SYSTEM INCLUDES
-
+#include <chrono>
+#include <iostream>
 
 // C++ PROJECT INCLUDES
 #include "catch/catch.hpp"
@@ -35,8 +36,7 @@ namespace Tests
         REQUIRE( p.GetState() == States::SettlementState::PENDING );
     }
 
-    TEST_CASE("Testing Promise Execution on Schedulers",
-        "[Promise_unit]")
+    TEST_CASE("Testing Promise Execution on Schedulers", "[Promise_unit]")
     {
         PromisePtr<int, int> pPromise =
             std::make_shared<Promise<int(int)> >();
@@ -50,22 +50,24 @@ namespace Tests
 
         pPromise->Schedule(pMockScheduler);
 
-        REQUIRE( pMockScheduler->
-            ExecuteWorkItem(pPromise->GetId()) );
+        std::cout << "Sleeping for 1 second to allow execution" << std::endl;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
         REQUIRE( pPromise->GetState() ==
             States::SettlementState::PENDING );
 
         pPromise->GiveArgs(5);
-        REQUIRE( pMockScheduler->
-            ExecuteWorkItem(pPromise->GetId()) );
+
+        std::cout << "Sleeping for 1 second to allow execution" << std::endl;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
         REQUIRE( pPromise->GetState() ==
             States::SettlementState::SUCCESS );
 
         REQUIRE( pPromise->GetResult() == 10 );
     }
 
-    TEST_CASE("Testing Promise Execution on Schedulers that Throw",
-        "[Promise_unit]")
+    TEST_CASE("Testing Promise Execution on Schedulers that Throw", "[Promise_unit]")
     {
         PromisePtr<int, int> pPromise =
             std::make_shared<Promise<int(int)> >();
@@ -79,14 +81,15 @@ namespace Tests
 
         pPromise->Schedule(pMockScheduler);
 
-        REQUIRE( pMockScheduler->
-            ExecuteWorkItem(pPromise->GetId()) );
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
         REQUIRE( pPromise->GetState() ==
             States::SettlementState::PENDING );
 
         pPromise->GiveArgs(5);
-        REQUIRE( pMockScheduler->
-            ExecuteWorkItem(pPromise->GetId()) );
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
         REQUIRE( pPromise->GetState() ==
             States::SettlementState::FAILURE );
 


### PR DESCRIPTION
This is major step 1 towards providing a client entry point into the
Framework. Each Scheduler now has a (3 thread) thread pool of
WorkerThreads for each type of priority of job I can think of. Now, we
have to wrap schedulers into a singleton entry point and we're game for
client use.
