### PR TITLE
linux changes

### DIFF
--- a/cpp/include/Async/AsyncExecution.hpp
+++ b/cpp/include/Async/AsyncExecution.hpp
@@ -13,6 +13,8 @@
 namespace Async
 {
 
+    EntryPoint::IEnginePtr GetEngine();
+
     template<typename PROMISE_RESULT> 
     PromisePtr<PROMISE_RESULT> Execute(std::function<PROMISE_RESULT()> pFunc,
                                        std::string& schedulerId)
@@ -34,8 +36,6 @@ namespace Async
         pPromise->Schedule(pScheduler);
         return pPromise;
     }
-
-    EntryPoint::IEnginePtr GetEngine();
 
 } // end of namespace Async
 

--- a/cpp/src/Async/unitTest/ContinuableWorkItem_unit.cpp
+++ b/cpp/src/Async/unitTest/ContinuableWorkItem_unit.cpp
@@ -59,7 +59,7 @@ namespace Tests
         auto pFailFunction = [&]() -> Types::Result_t
         {
             REQUIRE( pFailWorkItem->IsCurrentlyExecuting() );
-            throw std::exception("blah");
+            throw std::exception();
         };
 
         pSuccessWorkItem->AttachMainFunction(pSuccessFunction);

--- a/cpp/src/Async/unitTest/Promise_unit.cpp
+++ b/cpp/src/Async/unitTest/Promise_unit.cpp
@@ -68,7 +68,7 @@ namespace Tests
 
         pPromise->AttachMainFunction([]() -> int
         {
-            throw std::exception("Blah");
+            throw std::exception();
         });
 
         pPromise->Schedule(pMockScheduler);

--- a/cpp/src/Async/unitTest/WorkItemAndScheduler_unit.cpp
+++ b/cpp/src/Async/unitTest/WorkItemAndScheduler_unit.cpp
@@ -120,7 +120,7 @@ namespace Tests
 
         auto pThrowingFunction = []() -> Types::Result_t
         {
-            throw std::exception("Dummy exception");
+            throw std::exception();
         };
         auto pSuccessfulFunction = []() -> Types::Result_t
         {

--- a/cpp/src/Async/unitTest/WorkerThread_unit.cpp
+++ b/cpp/src/Async/unitTest/WorkerThread_unit.cpp
@@ -118,7 +118,7 @@ namespace Tests
 
         pWorkItem->AttachMainFunction([&]() -> Types::Result_t
         {
-            throw std::exception("blah");
+            throw std::exception();
         });
 
         REQUIRE( pWorkerThread->Queue(pWorkItem) == Types::Result_t::SUCCESS );


### PR DESCRIPTION
more std::exception(const char*) usage. Also needed to place
Async::GetEngine() BEFORE Async::Execute because G++ does not support
arbitrary function ordering.
