### PR TITLE
fixed a unix issue..declared function before using it

### DIFF
--- a/cpp/include/Async/IEngine.hpp
+++ b/cpp/include/Async/IEngine.hpp
@@ -3,13 +3,14 @@
 #define ASYNC_ENTRYPOINT_IENGINE_HPP
 
 // SYSTEM INCLUDES
+#include <atomic>
 #include <memory>
+#include <mutex>
 
 // C++ PROJECT INCLUDES
 #include "Async/LibraryExport.hpp"
 #include "Async/Result.hpp"
 #include "Async/IScheduler.hpp"
-#include "Async/Promise.hpp"
 
 namespace Async
 {

--- a/cpp/include/Async/SimpleChainLinker.hpp
+++ b/cpp/include/Async/SimpleChainLinker.hpp
@@ -61,11 +61,13 @@ namespace Async
         {
             return pFunc(value);
         });
-        if (!GetStaticEngine()->GetScheduler(this->_childSchedulerId))
+
+        EntryPoint::IEnginePtr pEngine = GetStaticEngine();
+        if (!pEngine->GetScheduler(this->_childSchedulerId))
         {
-            GetStaticEngine()->StartScheduler(this->_childSchedulerId);
+            pEngine->StartScheduler(this->_childSchedulerId);
         }
-        this->_pChild->Schedule(GetStaticEngine()->GetScheduler(this->_childSchedulerId));
+        this->_pChild->Schedule(pEngine->GetScheduler(this->_childSchedulerId));
         this->_pParent = nullptr;
         return Types::Result_t::SUCCESS;
     }

--- a/cpp/src/Async/unitTest/SimpleContinuation_unit.cpp
+++ b/cpp/src/Async/unitTest/SimpleContinuation_unit.cpp
@@ -36,5 +36,37 @@ namespace Tests
         REQUIRE( pSuccessor->GetResult() == 15 );
     }
 
+    TEST_CASE("Creating SimpleContinuations guarenteeing that Then() is called while Promise is executing",
+        "[SimpleContinuation_unit]")
+    {
+        std::string schedulerId = "testScheduler";
+        PromisePtr<int> pPromise = Execute<int>([]() -> int
+        {
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+            return 10;
+        }, schedulerId);
+
+        PromisePtr<int> pSuccessor = pPromise->Then<int>([](int a) -> int
+        {
+            return a + 5;
+        }, schedulerId);
+
+        while ( pPromise->GetState() == States::SettlementState::PENDING )
+        {
+            std::cout << "Sleeping for 1 second to allow execution" << std::endl;
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+        REQUIRE( pPromise->GetState() == States::SettlementState::SUCCESS );
+        REQUIRE( pPromise->GetResult() == 10 );
+
+        while( pSuccessor->GetState() == States::SettlementState::PENDING )
+        {
+            std::cout << "Sleeping for 1 second to allow execution" << std::endl;
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+        REQUIRE( pSuccessor->GetState() == States::SettlementState::SUCCESS );
+        REQUIRE( pSuccessor->GetResult() == 15 );
+    }
+
 } // end of namespace Tests
 } // end of namespace Async


### PR DESCRIPTION
Forgot to remove #include Promise.hpp from IEngine.hpp. This is bad,
because SimpleChainLinker.hpp is included in Promise.hpp, and uses
Async::GetStaticEngine() declared in IEngine.hpp.
So....SimpleChainLinker will be parsed BEFORE IEngine.hpp is done, so
GetStaticEngine() will be used BEFORE GetStaticEngine() is declared in
IEngine.hpp
