### PR TITLE
removed memory leak from unit tests

### DIFF
--- a/cpp/src/Async/unitTest/WorkerThread_unit.cpp
+++ b/cpp/src/Async/unitTest/WorkerThread_unit.cpp
@@ -98,7 +98,6 @@ namespace Tests
         pContinuableWorkItem->AttachMainFunction([&]() -> Types::Result_t
         {
             REQUIRE( pWorkerThread->GetState() == States::ConcurrencyState::BUSY );
-            REQUIRE( pContinuableWorkItem->GetState() == States::SettlementState::PENDING );
             return Types::Result_t::SUCCESS;
         });
 


### PR DESCRIPTION
unit test lambda captured work item it was operating on. This is
technically a memory leak.
