### PR TITLE
fixed invalid pointer bug for continuations

### DIFF
--- a/LocalBuild.py
+++ b/LocalBuild.py
@@ -8,6 +8,7 @@ import sys
 # PYTHON PROJECT IMPORTS
 sys.path.append("scripts")  # now we can import modules from <currentDirectory>/scripts
 import LocalBuildRules
+import GlobalBuildRules
 import Utilities
 import FileSystem
 

--- a/cpp/Execution/include/Async/Promise.hpp
+++ b/cpp/Execution/include/Async/Promise.hpp
@@ -88,11 +88,15 @@ PromisePtr<NEXT_RESULT> Promise<PROMISE_RESULT>::Then(std::function<NEXT_RESULT(
     std::string& childSchedulerId)
 {
     PromisePtr<NEXT_RESULT> pSuccessor = std::make_shared<Promise<NEXT_RESULT> >();
+    auto pContinuationFunction = [this, pFunc]() -> std::function<NEXT_RESULT()>
+    {
+        auto pBoundChildFunction = std::bind(pFunc, this->GetResult());
+        return pBoundChildFunction;
+    };
     IChainLinkerPtr pChain =
         std::make_shared<SimpleChainLinker<PROMISE_RESULT, NEXT_RESULT> >(
-            std::dynamic_pointer_cast<Promise<PROMISE_RESULT> >(shared_from_this()),
+            pContinuationFunction,
             pSuccessor,
-            pFunc,
             childSchedulerId
         );
     this->AddSuccessor(pChain, true);


### PR DESCRIPTION
No more pointer validation for parent promises, and worrying about
casting smart pointers. A std::function is used to bind the parent
result to the child's function, and a raw pointer is used. This is still
safe, as that pointer is guarenteed to exist, a continuation is executed
either from a user call (must have access to smart pointer of promise =
raw pointer exists) OR upon resolvement of the promise (raw pointer is
exisiting...WorkerThread has pointer to it)
