### PR TITLE
linux change.

### DIFF
--- a/cpp/Robos/src/Robos/unitTest/MasterNode_unit.cpp
+++ b/cpp/Robos/src/Robos/unitTest/MasterNode_unit.cpp
@@ -143,7 +143,7 @@ namespace Tests
                     REQUIRE( false );
                 }
             }
-        }   
+        }
     }
 
 } // end of Tests

--- a/cpp/Utilities/include/Utilities/btree.h
+++ b/cpp/Utilities/include/Utilities/btree.h
@@ -29,8 +29,12 @@
  * DEALINGS IN THE SOFTWARE.
  ******************************************************************************/
 
-#ifdef MSVC
-#   pragma warning( disable : 4996 )
+#ifdef _MSC_VER
+#   define Copy(x, y, z) std::_Copy_impl(x, y, z);
+#   define Copy_Backward(x, y, z) std::_Copy_backward(x, y, z);
+#else
+#   define Copy(x, y, z) std::copy(x, y, z);
+#   define Copy_Backward(x, y, z) std::copy_backward(x, y, z);
 #endif
 
 #ifndef STX_STX_BTREE_H_HEADER
@@ -1505,23 +1509,23 @@ private:
     }
 
     /// Convenient template function for conditional copying of slotdata. This
-    /// should be used instead of std::_Copy_impl for all slotdata manipulations.
+    /// should be used instead of std::copy for all slotdata manipulations.
     template <class InputIterator, class OutputIterator>
     static OutputIterator data_copy(InputIterator first, InputIterator last,
                                     OutputIterator result)
     {
         if (used_as_set) return result; // no operation
-        else return std::_Copy_impl(first, last, result);
+        else return Copy(first, last, result);
     }
 
     /// Convenient template function for conditional copying of slotdata. This
-    /// should be used instead of std::_Copy_impl for all slotdata manipulations.
+    /// should be used instead of std::copy for all slotdata manipulations.
     template <class InputIterator, class OutputIterator>
     static OutputIterator data_copy_backward(InputIterator first, InputIterator last,
                                              OutputIterator result)
     {
         if (used_as_set) return result; // no operation
-        else return std::_Copy_backward(first, last, result);
+        else return Copy_Backward(first, last, result);
     }
 
 public:
@@ -2049,7 +2053,7 @@ private:
             leaf_node* newleaf = allocate_leaf();
 
             newleaf->slotuse = leaf->slotuse;
-            std::_Copy_impl(leaf->slotkey, leaf->slotkey + leaf->slotuse, newleaf->slotkey);
+            Copy(leaf->slotkey, leaf->slotkey + leaf->slotuse, newleaf->slotkey);
             data_copy(leaf->slotdata, leaf->slotdata + leaf->slotuse, newleaf->slotdata);
 
             if (m_headleaf == NULL)
@@ -2072,7 +2076,7 @@ private:
             inner_node* newinner = allocate_inner(inner->level);
 
             newinner->slotuse = inner->slotuse;
-            std::_Copy_impl(inner->slotkey, inner->slotkey + inner->slotuse, newinner->slotkey);
+            Copy(inner->slotkey, inner->slotkey + inner->slotuse, newinner->slotkey);
 
             for (unsigned short slot = 0; slot <= inner->slotuse; ++slot)
             {
@@ -2265,9 +2269,9 @@ private:
                 // move items and put pointer to child node into correct slot
                 BTREE_ASSERT(slot >= 0 && slot <= inner->slotuse);
 
-                std::_Copy_backward(inner->slotkey + slot, inner->slotkey + inner->slotuse,
+                Copy_Backward(inner->slotkey + slot, inner->slotkey + inner->slotuse,
                                    inner->slotkey + inner->slotuse + 1);
-                std::_Copy_backward(inner->childid + slot, inner->childid + inner->slotuse + 1,
+                Copy_Backward(inner->childid + slot, inner->childid + inner->slotuse + 1,
                                    inner->childid + inner->slotuse + 2);
 
                 inner->slotkey[slot] = newkey;
@@ -2302,7 +2306,7 @@ private:
             // move items and put data item into correct data slot
             BTREE_ASSERT(slot >= 0 && slot <= leaf->slotuse);
 
-            std::_Copy_backward(leaf->slotkey + slot, leaf->slotkey + leaf->slotuse,
+            Copy_Backward(leaf->slotkey + slot, leaf->slotkey + leaf->slotuse,
                                leaf->slotkey + leaf->slotuse + 1);
             data_copy_backward(leaf->slotdata + slot, leaf->slotdata + leaf->slotuse,
                                leaf->slotdata + leaf->slotuse + 1);
@@ -2346,7 +2350,7 @@ private:
             newleaf->nextleaf->prevleaf = newleaf;
         }
 
-        std::_Copy_impl(leaf->slotkey + mid, leaf->slotkey + leaf->slotuse,
+        Copy(leaf->slotkey + mid, leaf->slotkey + leaf->slotuse,
                   newleaf->slotkey);
         data_copy(leaf->slotdata + mid, leaf->slotdata + leaf->slotuse,
                   newleaf->slotdata);
@@ -2384,9 +2388,9 @@ private:
 
         newinner->slotuse = inner->slotuse - (mid + 1);
 
-        std::_Copy_impl(inner->slotkey + mid + 1, inner->slotkey + inner->slotuse,
-                  newinner->slotkey);
-        std::_Copy_impl(inner->childid + mid + 1, inner->childid + inner->slotuse + 1,
+        Copy(inner->slotkey + mid + 1, inner->slotkey + inner->slotuse,
+             newinner->slotkey);
+        Copy(inner->childid + mid + 1, inner->childid + inner->slotuse     + 1,
                   newinner->childid);
 
         inner->slotuse = mid;
@@ -2696,7 +2700,7 @@ private:
 
             BTREE_PRINT("Found key in leaf " << curr << " at slot " << slot);
 
-            std::_Copy_impl(leaf->slotkey + slot + 1, leaf->slotkey + leaf->slotuse,
+            Copy(leaf->slotkey + slot + 1, leaf->slotkey + leaf->slotuse,
                       leaf->slotkey + slot);
             data_copy(leaf->slotdata + slot + 1, leaf->slotdata + leaf->slotuse,
                       leaf->slotdata + slot);
@@ -2868,9 +2872,9 @@ private:
 
                 free_node(inner->childid[slot]);
 
-                std::_Copy_impl(inner->slotkey + slot, inner->slotkey + inner->slotuse,
+                Copy(inner->slotkey + slot, inner->slotkey + inner->slotuse,
                           inner->slotkey + slot - 1);
-                std::_Copy_impl(inner->childid + slot + 1, inner->childid + inner->slotuse + 1,
+                Copy(inner->childid + slot + 1, inner->childid + inner->slotuse + 1,
                           inner->childid + slot);
 
                 inner->slotuse--;
@@ -2992,7 +2996,7 @@ private:
 
             BTREE_PRINT("Found iterator in leaf " << curr << " at slot " << slot);
 
-            std::_Copy_impl(leaf->slotkey + slot + 1, leaf->slotkey + leaf->slotuse,
+            Copy(leaf->slotkey + slot + 1, leaf->slotkey + leaf->slotuse,
                       leaf->slotkey + slot);
             data_copy(leaf->slotdata + slot + 1, leaf->slotdata + leaf->slotuse,
                       leaf->slotdata + slot);
@@ -3179,9 +3183,9 @@ private:
 
                 free_node(inner->childid[slot]);
 
-                std::_Copy_impl(inner->slotkey + slot, inner->slotkey + inner->slotuse,
+                Copy(inner->slotkey + slot, inner->slotkey + inner->slotuse,
                           inner->slotkey + slot - 1);
-                std::_Copy_impl(inner->childid + slot + 1, inner->childid + inner->slotuse + 1,
+                Copy(inner->childid + slot + 1, inner->childid + inner->slotuse + 1,
                           inner->childid + slot);
 
                 inner->slotuse--;
@@ -3272,7 +3276,7 @@ private:
 
         BTREE_ASSERT(left->slotuse + right->slotuse < leafslotmax);
 
-        std::_Copy_impl(right->slotkey, right->slotkey + right->slotuse,
+        Copy(right->slotkey, right->slotkey + right->slotuse,
                   left->slotkey + left->slotuse);
         data_copy(right->slotdata, right->slotdata + right->slotuse,
                   left->slotdata + left->slotuse);
@@ -3323,9 +3327,9 @@ private:
         left->slotuse++;
 
         // copy over keys and children from right
-        std::_Copy_impl(right->slotkey, right->slotkey + right->slotuse,
+        Copy(right->slotkey, right->slotkey + right->slotuse,
                   left->slotkey + left->slotuse);
-        std::_Copy_impl(right->childid, right->childid + right->slotuse + 1,
+        Copy(right->childid, right->childid + right->slotuse + 1,
                   left->childid + left->slotuse);
 
         left->slotuse += right->slotuse;
@@ -3356,7 +3360,7 @@ private:
 
         // copy the first items from the right node to the last slot in the left node.
 
-        std::_Copy_impl(right->slotkey, right->slotkey + shiftnum,
+        Copy(right->slotkey, right->slotkey + shiftnum,
                   left->slotkey + left->slotuse);
         data_copy(right->slotdata, right->slotdata + shiftnum,
                   left->slotdata + left->slotuse);
@@ -3365,7 +3369,7 @@ private:
 
         // shift all slots in the right node to the left
 
-        std::_Copy_impl(right->slotkey + shiftnum, right->slotkey + right->slotuse,
+        Copy(right->slotkey + shiftnum, right->slotkey + right->slotuse,
                   right->slotkey);
         data_copy(right->slotdata + shiftnum, right->slotdata + right->slotuse,
                   right->slotdata);
@@ -3420,9 +3424,9 @@ private:
 
         // copy the other items from the right node to the last slots in the left node.
 
-        std::_Copy_impl(right->slotkey, right->slotkey + shiftnum - 1,
+        Copy(right->slotkey, right->slotkey + shiftnum - 1,
                   left->slotkey + left->slotuse);
-        std::_Copy_impl(right->childid, right->childid + shiftnum,
+        Copy(right->childid, right->childid + shiftnum,
                   left->childid + left->slotuse);
 
         left->slotuse += shiftnum - 1;
@@ -3432,9 +3436,9 @@ private:
 
         // shift all slots in the right node
 
-        std::_Copy_impl(right->slotkey + shiftnum, right->slotkey + right->slotuse,
+        Copy(right->slotkey + shiftnum, right->slotkey + right->slotuse,
                   right->slotkey);
-        std::_Copy_impl(right->childid + shiftnum, right->childid + right->slotuse + 1,
+        Copy(right->childid + shiftnum, right->childid + right->slotuse + 1,
                   right->childid);
 
         right->slotuse -= shiftnum;
@@ -3476,7 +3480,7 @@ private:
 
         BTREE_ASSERT(right->slotuse + shiftnum < leafslotmax);
 
-        std::_Copy_backward(right->slotkey, right->slotkey + right->slotuse,
+        Copy_Backward(right->slotkey, right->slotkey + right->slotuse,
                            right->slotkey + right->slotuse + shiftnum);
         data_copy_backward(right->slotdata, right->slotdata + right->slotuse,
                            right->slotdata + right->slotuse + shiftnum);
@@ -3484,7 +3488,7 @@ private:
         right->slotuse += shiftnum;
 
         // copy the last items from the left node to the first slot in the right node.
-        std::_Copy_impl(left->slotkey + left->slotuse - shiftnum, left->slotkey + left->slotuse,
+        Copy(left->slotkey + left->slotuse - shiftnum, left->slotkey + left->slotuse,
                   right->slotkey);
         data_copy(left->slotdata + left->slotuse - shiftnum, left->slotdata + left->slotuse,
                   right->slotdata);
@@ -3527,9 +3531,9 @@ private:
 
         BTREE_ASSERT(right->slotuse + shiftnum < innerslotmax);
 
-        std::_Copy_backward(right->slotkey, right->slotkey + right->slotuse,
+        Copy_Backward(right->slotkey, right->slotkey + right->slotuse,
                            right->slotkey + right->slotuse + shiftnum);
-        std::_Copy_backward(right->childid, right->childid + right->slotuse + 1,
+        Copy_Backward(right->childid, right->childid + right->slotuse + 1,
                            right->childid + right->slotuse + 1 + shiftnum);
 
         right->slotuse += shiftnum;
@@ -3538,9 +3542,9 @@ private:
         right->slotkey[shiftnum - 1] = parent->slotkey[parentslot];
 
         // copy the remaining last items from the left node to the first slot in the right node.
-        std::_Copy_impl(left->slotkey + left->slotuse - shiftnum + 1, left->slotkey + left->slotuse,
+        Copy(left->slotkey + left->slotuse - shiftnum + 1, left->slotkey + left->slotuse,
                   right->slotkey);
-        std::_Copy_impl(left->childid + left->slotuse - shiftnum + 1, left->childid + left->slotuse + 1,
+        Copy(left->childid + left->slotuse - shiftnum + 1, left->childid + left->slotuse + 1,
                   right->childid);
 
         // copy the first to-be-removed key from the left node to the parent's decision slot


### PR DESCRIPTION
std::copy and std::copy_backwards generate a warning on Windows b/c
Microsoft wants people to use their version. We have warnings set to
trigger as errors, so I made macros to expand to the windows version on
Windows and the stdlib version on Unix.
