### PR TITLE
python include redefinition

### DIFF
--- a/cpp/Robos/src/Robos/PyNodeBase.cpp
+++ b/cpp/Robos/src/Robos/PyNodeBase.cpp
@@ -1,8 +1,9 @@
+#include "Robos/PyNodeBase.hpp"
+
 // SYSTEM INCLUDES
 #include <iostream>
 
 // C++ PROJECT INCLUDES
-#include "Robos/PyNodeBase.hpp"
 
 namespace Robos
 {


### PR DESCRIPTION
Have to make #include <Python.h> the first line before any system
includes.
